### PR TITLE
Hoodi fixes and tweaks

### DIFF
--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -19,7 +19,7 @@ export function loadAbiFromFile(contractName: string, address: string): Abi | ne
     logErrorAndExit(
       `Error finding ABI file for contract
         ${contractName} in ${g_Arguments.abiDirPath}: ${printError(error)}\n\n` +
-        chalk.yellow.bold(`Try running with the 'abi-update' option to download the unnecessary ABI`),
+        chalk.yellow.bold(`Try running with the '--update-abi' option to download the unnecessary ABI`),
     );
   }
   return loadAbiFromAbiPath(abiPath);

--- a/src/boilerplate-generator.ts
+++ b/src/boilerplate-generator.ts
@@ -37,7 +37,11 @@ export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument
         `The field ${chalk.magenta(`explorerHostname`)} is required in the ${chalk.magenta(g_Arguments.configPath)}`,
       );
     }
-    const { contractName, implementation } = await loadContractInfoFromExplorer(address, explorerHostname, explorerKey);
+    const contractInfo = await loadContractInfoFromExplorer(address, explorerHostname, explorerKey);
+    if (!contractInfo) {
+      return;
+    }
+    const { contractName, implementation } = contractInfo;
 
     const provider = new JsonRpcProvider(rpcUrl);
     let contractEntryIfProxy;

--- a/src/explorer-provider.ts
+++ b/src/explorer-provider.ts
@@ -4,7 +4,7 @@ import { Contract, JsonRpcProvider } from "ethers";
 import { printError } from "./common";
 import { EtherscanHandler } from "./explorers/etherscan";
 import { ModeHandler } from "./explorers/mode";
-import { logError, logErrorAndExit, logReplaceLine } from "./logger";
+import { LogCommand, logError, logErrorAndExit, logReplaceLine } from "./logger";
 import {
   Abi,
   AbiArgumentsLength,
@@ -77,7 +77,7 @@ export async function loadContractInfoFromExplorer(
   address: string,
   explorerHostname: string,
   explorerKey?: string,
-): Promise<ContractInfo> {
+): Promise<ContractInfo | undefined> {
   return loadContractInfo(
     explorerHostname.includes("mode.network") ? new ModeHandler() : new EtherscanHandler(),
     address,
@@ -112,15 +112,32 @@ export async function loadContractInfo(
     logErrorAndExit(`It seems, explorer response has changed:\n${JSON.stringify(sourcesResponse)}`);
   }
 
-  const abi: unknown = _parseJson(sourcesResponse.result[0].ABI);
+  try {
+    const abi: unknown = JSON.parse(sourcesResponse.result[0].ABI);
 
-  if (!isValidAbi(abi)) {
-    logErrorAndExit(`ABI for contract ${chalk.yellow(address)} is not valid (type mismatch):\n${JSON.stringify(abi)}`);
+    if (!isValidAbi(abi)) {
+      logErrorAndExit(
+        `ABI for contract ${chalk.yellow(address)} is not valid (type mismatch):\n${JSON.stringify(abi)}`,
+      );
+    }
+
+    const contractInfo = explorer.getContractInfo(
+      explorer,
+      abi,
+      sourcesResponse,
+      address,
+      explorerHostname,
+      explorerKey,
+    );
+
+    return contractInfo;
+  } catch {
+    const logHandler = new LogCommand(`ABI ${chalk.magenta(`${address}`)}`);
+    logHandler.failure(
+      `Failed to parse contract source code (${chalk.yellow(sourcesResponse.result[0].ABI)}). Maybe EOF?`,
+    );
+    return;
   }
-
-  const contractInfo = explorer.getContractInfo(explorer, abi, sourcesResponse, address, explorerHostname, explorerKey);
-
-  return contractInfo;
 }
 
 export async function httpGetAsync<T>(url: string): Promise<T> | never {

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -160,6 +160,9 @@ async function iterateLoadedContracts<T extends EntireDocument | SeedDocument>(
       }
       for (const address of addresses) {
         const contractInfo = await loadContractInfoFromExplorer(address, explorerHostname, explorerKey);
+        if (!contractInfo) {
+          continue;
+        }
         await callback(contractInfo);
       }
     }

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -113,16 +113,15 @@ async function doChecks(jsonDocument: EntireDocument) {
   for (const [sectionTitle, section] of Object.entries(jsonDocument)) {
     if (isTypeOfTB(section, NetworkSectionTB)) await checkNetworkSection(sectionTitle, section);
   }
-  log(chalk.bold(`\n${g_total_checks} checks performed.`));
-  if (g_errors) {
-    log(`\n${FAILURE_MARK} ${chalk.bold(`${g_errors} errors found!`)} `);
-    process.exit(2);
-  }
-
   if (g_Arguments.checkOnly) {
     log(
       `\n${WARNING_MARK}${WARNING_MARK}${WARNING_MARK} Checks run only for "${chalk.bold(chalk.blue(g_Arguments.checkOnlyCmdArg))}"\n`,
     );
+  }
+  log(chalk.bold(`\n${g_total_checks} checks performed.`));
+  if (g_errors) {
+    log(`\n${FAILURE_MARK} ${chalk.bold(`${g_errors} errors found!`)} `);
+    process.exit(2);
   }
 }
 

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -121,7 +121,7 @@ async function doChecks(jsonDocument: EntireDocument) {
   log(chalk.bold(`\n${g_total_checks} checks performed.`));
   if (g_errors) {
     log(`\n${FAILURE_MARK} ${chalk.bold(`${g_errors} errors found!`)} `);
-    process.exit(2);
+    process.exit(g_errors);
   }
 }
 

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -90,14 +90,24 @@ const ChecksEntryValueTB = Type.Readonly(
 );
 
 const ProxyChecksTB = Type.Readonly(
-  Type.Object(
-    {
-      proxy__getImplementation: Type.Optional(Type.Union([EthereumStringTB, Type.Null()])),
-      proxy__getAdmin: Type.Optional(Type.Union([EthereumStringTB, Type.Null()])),
-      proxy__getIsOssified: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
-    },
-    { additionalProperties: false },
-  ),
+  Type.Union([
+    Type.Object(
+      {
+        proxy__getImplementation: Type.Optional(Type.Union([EthereumStringTB, Type.Null()])),
+        proxy__getAdmin: Type.Optional(Type.Union([EthereumStringTB, Type.Null()])),
+        proxy__getIsOssified: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        implementation: Type.Optional(Type.Union([EthereumStringTB, Type.Null()])),
+        proxy_getAdmin: Type.Optional(Type.Union([EthereumStringTB, Type.Null()])),
+        proxy_getIsOssified: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+      },
+      { additionalProperties: false },
+    ),
+  ]),
 );
 
 const Sr2ProxyChecksTB = Type.Readonly(


### PR DESCRIPTION
## What’s Changed
-  Detect and handle older-style proxy contracts (e.g. `0x79e52DbA27718B1b618FC519A8F05a1386F4A8d2`).

- Correct the misreported flag in the “update ABI” error.

-  Move the `checkOnly` warning block above the summary and `process.exit(2)` call.

-  Emit a warning (not a crash) when contract source code is unavailable:
![image](https://github.com/user-attachments/assets/3b67fb2d-2a18-483a-8e81-f8e92a958f5c)
