### PR TITLE
Feat: add error tracking

### DIFF
--- a/src/section-validators/contract.ts
+++ b/src/section-validators/contract.ts
@@ -4,7 +4,7 @@ import { EntryField } from "src/common";
 import { logHeader1, logHeader2 } from "src/logger";
 import { ContractEntry } from "src/typebox";
 
-import { CheckLevel, needCheck, SectionValidatorBase } from "./base";
+import { CheckLevel, clearErrorContext, needCheck, SectionValidatorBase, setErrorContext } from "./base";
 import { ChecksSectionValidator } from "./checks";
 import { ImplementationChecksSectionValidator } from "./implementation-checks";
 import { OzAclSectionValidator } from "./oz-acl";
@@ -58,25 +58,40 @@ export class ContractSectionValidator {
 
     logHeader1(`Contract (${sectionTitle}): ${contractAlias} (${contractEntry.name}, ${contractEntry.address})`);
 
+    // Set base error context for this contract
+    setErrorContext({
+      section: sectionTitle,
+      contract: contractAlias,
+      contractAddress: contractEntry.address,
+    });
+
     if (needCheck(CheckLevel.checksType, EntryField.checks)) {
       logHeader2(EntryField.checks);
+      setErrorContext({ checksType: EntryField.checks });
       await this.map.get(EntryField.checks)!.validateSection(contractEntry, contractAlias);
     }
 
     if (needCheck(CheckLevel.checksType, EntryField.proxyChecks)) {
+      setErrorContext({ checksType: EntryField.proxyChecks });
       await this.map.get(EntryField.proxyChecks)!.validateSection(contractEntry, contractAlias);
     }
 
     if (needCheck(CheckLevel.checksType, EntryField.ozNonEnumerableAcl)) {
+      setErrorContext({ checksType: EntryField.ozNonEnumerableAcl });
       await this.map.get(EntryField.ozNonEnumerableAcl)!.validateSection(contractEntry, contractAlias);
     }
 
     if (needCheck(CheckLevel.checksType, EntryField.implementationChecks)) {
+      setErrorContext({ checksType: EntryField.implementationChecks });
       await this.map.get(EntryField.implementationChecks)!.validateSection(contractEntry, contractAlias);
     }
 
     if (needCheck(CheckLevel.checksType, EntryField.ozAcl)) {
+      setErrorContext({ checksType: EntryField.ozAcl });
       await this.map.get(EntryField.ozAcl)!.validateSection(contractEntry, contractAlias);
     }
+
+    // Clear error context after contract validation
+    clearErrorContext();
   }
 }

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -16,7 +16,7 @@ import { parseCmdLineArguments } from "./cli-parser";
 import { printError, readUrlOrFromEnvironment } from "./common";
 import { loadContractInfoFromExplorer } from "./explorer-provider";
 import { FAILURE_MARK, log, logError, logErrorAndExit, logHeader1, WARNING_MARK } from "./logger";
-import { g_errors, g_total_checks } from "./section-validators/base";
+import { g_error_details, g_errors, g_total_checks } from "./section-validators/base";
 import { ContractSectionValidator } from "./section-validators/contract";
 import {
   EntireDocument,
@@ -121,6 +121,25 @@ async function doChecks(jsonDocument: EntireDocument) {
   log(chalk.bold(`\n${g_total_checks} checks performed.`));
   if (g_errors) {
     log(`\n${FAILURE_MARK} ${chalk.bold(`${g_errors} errors found!`)} `);
+
+    // Display detailed error summary
+    if (g_error_details.length > 0) {
+      logHeader1("Error Summary");
+      for (let index = 0; index < g_error_details.length; index++) {
+        const error = g_error_details[index];
+        log(
+          `\n${chalk.red(`[${index + 1}/${g_error_details.length}]`)} ` +
+            `${chalk.cyan("Section:")} ${chalk.yellow(error.section)} | ` +
+            `${chalk.cyan("Contract:")} ${chalk.yellow(error.contract)} ` +
+            `${chalk.gray(`(${error.contractAddress})`)}` +
+            `\n    ${chalk.cyan("Check Type:")} ${chalk.yellow(error.checksType)} | ` +
+            `${chalk.cyan("Method:")} ${chalk.yellow(error.method)}` +
+            `\n    ${chalk.cyan("Error:")} ${chalk.red(error.message)}`,
+        );
+      }
+      log(""); // Empty line at the end
+    }
+
     process.exit(g_errors);
   }
 }


### PR DESCRIPTION
Output all of the errors encountered during the checks as a final summary.

Example:

<img width="1015" height="495" alt="image" src="https://github.com/user-attachments/assets/02237b8f-d143-4b19-a997-12c744ca5633" />
