### PR TITLE
feat: add exhaustive event-based validation for non-enumerable OZ ACL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ reports
 
 # pycharm
 .idea
+
+# Auto-generated schemas
+schemas/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ yarn start path/to/config.seed.yaml --generate
 
 Config is a yaml file that contains all the required addresses, parameters, view functions with their expected results for verification. The outline of the config is given below,
 
-```yaml
+````yaml
 # Sample config
 
 parameters:
@@ -124,7 +124,22 @@ l1:
         getFoo: *FOO
       ozAcl:
         *DEFAULT_ADMIN_ROLE : [*adminMultisig]
-```
+
+### Exhaustive non-enumerable OZ ACL checks
+
+For `ozNonEnumerableAcl`, you can opt into exhaustive checks that scan role events to detect every current role holder:
+
+```yaml
+ozNonEnumerableAclOptions:
+  exhaustive: true
+  eventBatchSize: 5000
+````
+
+When `exhaustive: true`, any role that appears in events but is **not** listed in `ozNonEnumerableAcl` is treated as an error. Make sure all roles that can exist on the contract are present in the config.
+
+Use `--cache` to enable local caching for event scans, and adjust `eventBatchSize` if your RPC provider enforces stricter log limits.
+
+````
 
 ### ABIs
 
@@ -141,7 +156,7 @@ For large projects with many contracts, you can consolidate all individual ABI f
 
 ```sh
 yarn consolidate-abi path/to/config/abi --compress
-```
+````
 
 This command:
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "format:fix": "prettier . --ignore-path .gitignore --write",
     "postinstall": "husky",
     "test": "ts-node src/test-util/app.ts",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "schemas": "ts-node src/gen-schemas.ts"
   },
   "lint-staged": {
@@ -52,7 +54,8 @@
     "lint-staged": "^15.2.7",
     "prettier": "^3.3.2",
     "ts-node": ">=8.0.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.0.0"
   },
   "dependencies": {
     "@inquirer/prompts": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "ts-node src/test-util/app.ts",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "schemas": "ts-node src/gen-schemas.ts"
+    "schemas": "ts-node src/gen-schemas.ts",
+    "clear-cache": "ts-node src/clear-cache.ts"
   },
   "lint-staged": {
     "./**.{ts,md,json}": [

--- a/src/__tests__/cache-provider.test.ts
+++ b/src/__tests__/cache-provider.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearCacheState,
+  flushCacheUpdates,
+  initCacheDirectory,
+  loadCreationBlockFromCache,
+  loadEventScanFromCache,
+  RoleHoldersMap,
+  saveCreationBlockToCache,
+  saveEventScanToCache,
+} from "../cache-provider";
+
+describe("cache-provider", () => {
+  let testDirectory: string;
+  let testConfigPath: string;
+
+  beforeEach(() => {
+    // Create a temporary directory for each test
+    testDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "state-mate-cache-test-"));
+    testConfigPath = path.join(testDirectory, "test-config.yaml");
+    // Create a dummy config file
+    fs.writeFileSync(testConfigPath, "test: true");
+    // Reset cache state
+    clearCacheState();
+    // Initialize with test config path
+    initCacheDirectory(testConfigPath);
+  });
+
+  afterEach(() => {
+    // Clean up temporary directory
+    clearCacheState();
+    fs.rmSync(testDirectory, { recursive: true, force: true });
+  });
+
+  describe("creation block cache", () => {
+    it("returns null for uncached address", () => {
+      const result = loadCreationBlockFromCache("0x1234567890123456789012345678901234567890");
+      expect(result).toBeNull();
+    });
+
+    it("round trip works - save and load", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      const blockNumber = 12_345_678;
+      const txHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      const deployer = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+      saveCreationBlockToCache(address, blockNumber, txHash, deployer);
+      const result = loadCreationBlockFromCache(address);
+
+      expect(result).not.toBeNull();
+      expect(result?.blockNumber).toBe(blockNumber);
+      expect(result?.txHash).toBe(txHash);
+      expect(result?.deployer).toBe(deployer);
+    });
+
+    it("normalizes addresses to lowercase", () => {
+      const address = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12";
+      const blockNumber = 12_345_678;
+
+      saveCreationBlockToCache(address, blockNumber, "0x123", "0xdeployer");
+
+      // Query with lowercase
+      const result = loadCreationBlockFromCache(address.toLowerCase());
+      expect(result).not.toBeNull();
+      expect(result?.blockNumber).toBe(blockNumber);
+    });
+
+    it("persists to disk after flush", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      saveCreationBlockToCache(address, 12_345, "0xhash", "0xdeployer");
+      flushCacheUpdates();
+
+      const cacheFile = path.join(testDirectory, "cache", "creation-blocks.json");
+      expect(fs.existsSync(cacheFile)).toBe(true);
+
+      const content = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+      expect(content.entries[address.toLowerCase()]).toBeDefined();
+    });
+  });
+
+  describe("event scan cache", () => {
+    it("returns null for uncached scan", () => {
+      const result = loadEventScanFromCache("0x1234567890123456789012345678901234567890", 100_000);
+      expect(result).toBeNull();
+    });
+
+    it("round trip works - save and load", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      const currentBlock = 100_000;
+      const roleHolders: RoleHoldersMap = new Map();
+      const roleId = "0x0000000000000000000000000000000000000000000000000000000000000001";
+      const holder = "0xholder1234567890holder1234567890holder12";
+      roleHolders.set(roleId, new Set([holder]));
+
+      saveEventScanToCache(address, roleHolders, currentBlock);
+      const result = loadEventScanFromCache(address, currentBlock);
+
+      expect(result).not.toBeNull();
+      expect(result?.get(roleId)?.has(holder)).toBe(true);
+    });
+
+    it("returns null if current block is ahead of cached block", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      const cachedBlock = 100_000;
+      const currentBlock = 100_001;
+      const roleHolders: RoleHoldersMap = new Map();
+
+      saveEventScanToCache(address, roleHolders, cachedBlock);
+      const result = loadEventScanFromCache(address, currentBlock);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns cached data if current block equals cached block", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      const blockNumber = 100_000;
+      const roleHolders: RoleHoldersMap = new Map();
+      roleHolders.set("role1", new Set(["holder1"]));
+
+      saveEventScanToCache(address, roleHolders, blockNumber);
+      const result = loadEventScanFromCache(address, blockNumber);
+
+      expect(result).not.toBeNull();
+      expect(result?.get("role1")?.has("holder1")).toBe(true);
+    });
+
+    it("persists to disk after flush", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      const roleHolders: RoleHoldersMap = new Map();
+      roleHolders.set("role1", new Set(["holder1"]));
+
+      saveEventScanToCache(address, roleHolders, 100_000);
+      flushCacheUpdates();
+
+      const cacheFile = path.join(testDirectory, "cache", "event-scans.json");
+      expect(fs.existsSync(cacheFile)).toBe(true);
+
+      const content = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+      expect(content.entries[address.toLowerCase()]).toBeDefined();
+    });
+  });
+
+  describe("cache persistence", () => {
+    it("loads existing cache from disk on re-initialization", () => {
+      const address = "0x1234567890123456789012345678901234567890";
+      saveCreationBlockToCache(address, 12_345, "0xhash", "0xdeployer");
+      flushCacheUpdates();
+
+      // Clear in-memory cache and re-initialize
+      clearCacheState();
+      initCacheDirectory(testConfigPath);
+
+      const result = loadCreationBlockFromCache(address);
+      expect(result).not.toBeNull();
+      expect(result?.blockNumber).toBe(12_345);
+    });
+  });
+});

--- a/src/__tests__/event-scanner.test.ts
+++ b/src/__tests__/event-scanner.test.ts
@@ -1,0 +1,199 @@
+import { Log } from "ethers";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRoleHoldersFromEvents,
+  mergeRoleHolders,
+  parseRoleEvent,
+  RoleEvent,
+  ROLE_GRANTED_TOPIC,
+  ROLE_REVOKED_TOPIC,
+} from "../event-scanner";
+
+// Helper to create mock Log objects
+function createMockLog(
+  topic0: string,
+  role: string,
+  account: string,
+  sender: string,
+  blockNumber: number,
+  txHash: string,
+): Log {
+  // Pad addresses to 32 bytes (topics are 32 bytes)
+  const paddedRole = role.padEnd(66, "0").slice(0, 66);
+  const paddedAccount = "0x" + "0".repeat(24) + account.slice(2).toLowerCase();
+  const paddedSender = "0x" + "0".repeat(24) + sender.slice(2).toLowerCase();
+
+  return {
+    topics: [topic0, paddedRole, paddedAccount, paddedSender],
+    blockNumber,
+    transactionHash: txHash,
+    // These are not used by parseRoleEvent but required by Log type
+    address: "0x1234567890123456789012345678901234567890",
+    data: "0x",
+    index: 0,
+    transactionIndex: 0,
+    removed: false,
+    blockHash: "0x" + "0".repeat(64),
+    toJSON: () => ({}),
+    getBlock: async () => null as never,
+    getTransaction: async () => null as never,
+    getTransactionReceipt: async () => null as never,
+    removedEvent: () => null as never,
+    provider: null as never,
+  } as unknown as Log;
+}
+
+describe("parseRoleEvent", () => {
+  const testRole = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const testAccount = "0x1234567890123456789012345678901234567890";
+  const testSender = "0xabcdef1234567890abcdef1234567890abcdef12";
+
+  it("correctly parses RoleGranted events", () => {
+    const log = createMockLog(ROLE_GRANTED_TOPIC, testRole, testAccount, testSender, 12_345, "0xabc123");
+
+    const result = parseRoleEvent(log);
+
+    expect(result.eventType).toBe("granted");
+    expect(result.role).toBe(testRole);
+    expect(result.account).toBe(testAccount.toLowerCase());
+    expect(result.blockNumber).toBe(12_345);
+    expect(result.transactionHash).toBe("0xabc123");
+  });
+
+  it("correctly parses RoleRevoked events", () => {
+    const log = createMockLog(ROLE_REVOKED_TOPIC, testRole, testAccount, testSender, 12_346, "0xdef456");
+
+    const result = parseRoleEvent(log);
+
+    expect(result.eventType).toBe("revoked");
+    expect(result.role).toBe(testRole);
+    expect(result.account).toBe(testAccount.toLowerCase());
+    expect(result.blockNumber).toBe(12_346);
+  });
+});
+
+describe("buildRoleHoldersFromEvents", () => {
+  const roleA = "0x0000000000000000000000000000000000000000000000000000000000000001";
+  const roleB = "0x0000000000000000000000000000000000000000000000000000000000000002";
+  const holder1 = "0x1111111111111111111111111111111111111111";
+  const holder2 = "0x2222222222222222222222222222222222222222";
+  const sender = "0x3333333333333333333333333333333333333333";
+
+  it("builds correct map from grant events", () => {
+    const events: RoleEvent[] = [
+      { role: roleA, account: holder1, sender, blockNumber: 100, transactionHash: "0x1", eventType: "granted" },
+      { role: roleA, account: holder2, sender, blockNumber: 101, transactionHash: "0x2", eventType: "granted" },
+    ];
+
+    const result = buildRoleHoldersFromEvents(events);
+
+    expect(result.get(roleA)?.has(holder1)).toBe(true);
+    expect(result.get(roleA)?.has(holder2)).toBe(true);
+    expect(result.get(roleA)?.size).toBe(2);
+  });
+
+  it("handles revoke events correctly", () => {
+    const events: RoleEvent[] = [
+      { role: roleA, account: holder1, sender, blockNumber: 100, transactionHash: "0x1", eventType: "granted" },
+      { role: roleA, account: holder1, sender, blockNumber: 200, transactionHash: "0x2", eventType: "revoked" },
+    ];
+
+    const result = buildRoleHoldersFromEvents(events);
+
+    expect(result.get(roleA)?.has(holder1)).toBe(false);
+    expect(result.get(roleA)?.size).toBe(0);
+  });
+
+  it("processes events in chronological order", () => {
+    // Events are out of order but should be sorted by block number
+    const events: RoleEvent[] = [
+      { role: roleA, account: holder1, sender, blockNumber: 200, transactionHash: "0x2", eventType: "revoked" },
+      { role: roleA, account: holder1, sender, blockNumber: 100, transactionHash: "0x1", eventType: "granted" },
+    ];
+
+    const result = buildRoleHoldersFromEvents(events);
+
+    // After sorting: grant at 100, revoke at 200 -> holder should be removed
+    expect(result.get(roleA)?.has(holder1)).toBe(false);
+  });
+
+  it("handles multiple roles per address", () => {
+    const events: RoleEvent[] = [
+      { role: roleA, account: holder1, sender, blockNumber: 100, transactionHash: "0x1", eventType: "granted" },
+      { role: roleB, account: holder1, sender, blockNumber: 101, transactionHash: "0x2", eventType: "granted" },
+    ];
+
+    const result = buildRoleHoldersFromEvents(events);
+
+    expect(result.get(roleA)?.has(holder1)).toBe(true);
+    expect(result.get(roleB)?.has(holder1)).toBe(true);
+  });
+
+  it("empty events returns empty map", () => {
+    const result = buildRoleHoldersFromEvents([]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("handles grant-revoke-grant sequence", () => {
+    const events: RoleEvent[] = [
+      { role: roleA, account: holder1, sender, blockNumber: 100, transactionHash: "0x1", eventType: "granted" },
+      { role: roleA, account: holder1, sender, blockNumber: 200, transactionHash: "0x2", eventType: "revoked" },
+      { role: roleA, account: holder1, sender, blockNumber: 300, transactionHash: "0x3", eventType: "granted" },
+    ];
+
+    const result = buildRoleHoldersFromEvents(events);
+
+    expect(result.get(roleA)?.has(holder1)).toBe(true);
+  });
+});
+
+describe("mergeRoleHolders", () => {
+  const roleA = "0x0000000000000000000000000000000000000000000000000000000000000001";
+  const holder1 = "0x1111111111111111111111111111111111111111";
+  const holder2 = "0x2222222222222222222222222222222222222222";
+  const sender = "0x3333333333333333333333333333333333333333";
+
+  it("merges new events with existing role holders", () => {
+    const base = new Map<string, Set<string>>();
+    base.set(roleA, new Set([holder1]));
+
+    const newEvents: RoleEvent[] = [
+      { role: roleA, account: holder2, sender, blockNumber: 200, transactionHash: "0x2", eventType: "granted" },
+    ];
+
+    const result = mergeRoleHolders(base, newEvents);
+
+    expect(result.get(roleA)?.has(holder1)).toBe(true);
+    expect(result.get(roleA)?.has(holder2)).toBe(true);
+    expect(result.get(roleA)?.size).toBe(2);
+  });
+
+  it("does not modify the original base map", () => {
+    const base = new Map<string, Set<string>>();
+    base.set(roleA, new Set([holder1]));
+
+    const newEvents: RoleEvent[] = [
+      { role: roleA, account: holder2, sender, blockNumber: 200, transactionHash: "0x2", eventType: "granted" },
+    ];
+
+    mergeRoleHolders(base, newEvents);
+
+    // Original base should be unchanged
+    expect(base.get(roleA)?.has(holder2)).toBe(false);
+  });
+
+  it("handles revoke in new events removing from base", () => {
+    const base = new Map<string, Set<string>>();
+    base.set(roleA, new Set([holder1]));
+
+    const newEvents: RoleEvent[] = [
+      { role: roleA, account: holder1, sender, blockNumber: 200, transactionHash: "0x2", eventType: "revoked" },
+    ];
+
+    const result = mergeRoleHolders(base, newEvents);
+
+    expect(result.get(roleA)?.has(holder1)).toBe(false);
+  });
+});

--- a/src/__tests__/typebox-schema.test.ts
+++ b/src/__tests__/typebox-schema.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { isTypeOfTB, OzNonEnumerableAclOptionsTB, ProxyContractEntryTB } from "../typebox";
+
+describe("OzNonEnumerableAclOptionsTB schema", () => {
+  it("validates correct structure with exhaustive", () => {
+    const valid = {
+      exhaustive: true,
+    };
+    expect(isTypeOfTB(valid, OzNonEnumerableAclOptionsTB)).toBe(true);
+  });
+
+  it("validates correct structure with eventBatchSize", () => {
+    const valid = {
+      eventBatchSize: 5000,
+    };
+    expect(isTypeOfTB(valid, OzNonEnumerableAclOptionsTB)).toBe(true);
+  });
+
+  it("validates correct structure with both options", () => {
+    const valid = {
+      exhaustive: true,
+      eventBatchSize: 3000,
+    };
+    expect(isTypeOfTB(valid, OzNonEnumerableAclOptionsTB)).toBe(true);
+  });
+
+  it("validates empty object (all fields optional)", () => {
+    const valid = {};
+    expect(isTypeOfTB(valid, OzNonEnumerableAclOptionsTB)).toBe(true);
+  });
+
+  it("rejects invalid properties", () => {
+    const invalid = {
+      exhaustive: true,
+      unknownField: "value",
+    };
+    expect(isTypeOfTB(invalid, OzNonEnumerableAclOptionsTB)).toBe(false);
+  });
+
+  it("rejects wrong type for exhaustive", () => {
+    const invalid = {
+      exhaustive: "true", // should be boolean
+    };
+    expect(isTypeOfTB(invalid, OzNonEnumerableAclOptionsTB)).toBe(false);
+  });
+
+  it("rejects wrong type for eventBatchSize", () => {
+    const invalid = {
+      eventBatchSize: "5000", // should be number
+    };
+    expect(isTypeOfTB(invalid, OzNonEnumerableAclOptionsTB)).toBe(false);
+  });
+});
+
+describe("ProxyContractEntryTB with ozNonEnumerableAclOptions", () => {
+  const baseProxyContract = {
+    address: "0x1234567890123456789012345678901234567890",
+    name: "TestContract",
+    proxyName: "OssifiableProxy",
+    checks: {},
+  };
+
+  it("accepts contract entry with ozNonEnumerableAclOptions", () => {
+    const validEntry = {
+      ...baseProxyContract,
+      ozNonEnumerableAcl: {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": [
+          "0xabcdef1234567890abcdef1234567890abcdef12",
+        ],
+      },
+      ozNonEnumerableAclOptions: {
+        exhaustive: true,
+        eventBatchSize: 3000,
+      },
+    };
+    expect(isTypeOfTB(validEntry, ProxyContractEntryTB)).toBe(true);
+  });
+
+  it("accepts contract entry without ozNonEnumerableAclOptions (backward compatible)", () => {
+    const validEntry = {
+      ...baseProxyContract,
+      ozNonEnumerableAcl: {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": [
+          "0xabcdef1234567890abcdef1234567890abcdef12",
+        ],
+      },
+    };
+    expect(isTypeOfTB(validEntry, ProxyContractEntryTB)).toBe(true);
+  });
+
+  it("accepts contract entry with only exhaustive option", () => {
+    const validEntry = {
+      ...baseProxyContract,
+      ozNonEnumerableAclOptions: {
+        exhaustive: true,
+      },
+    };
+    expect(isTypeOfTB(validEntry, ProxyContractEntryTB)).toBe(true);
+  });
+
+  it("rejects contract entry with invalid ozNonEnumerableAclOptions", () => {
+    const invalidEntry = {
+      ...baseProxyContract,
+      ozNonEnumerableAclOptions: {
+        exhaustive: "yes", // should be boolean
+      },
+    };
+    expect(isTypeOfTB(invalidEntry, ProxyContractEntryTB)).toBe(false);
+  });
+});
+
+describe("Backward compatibility", () => {
+  it("existing config without options still validates", () => {
+    const existingConfig = {
+      address: "0x1234567890123456789012345678901234567890",
+      name: "L1ERC20TokenBridge",
+      proxyName: "OssifiableProxy",
+      implementation: "0xabcdef1234567890abcdef1234567890abcdef12",
+      proxyChecks: {
+        proxy__getImplementation: "0xabcdef1234567890abcdef1234567890abcdef12",
+      },
+      checks: {
+        isInitialized: true,
+        isDepositsEnabled: true,
+      },
+      ozNonEnumerableAcl: {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": [
+          "0x3e40d73eb977dc6a537af587d48316fee66e9c8c",
+        ],
+      },
+    };
+    expect(isTypeOfTB(existingConfig, ProxyContractEntryTB)).toBe(true);
+  });
+});

--- a/src/__tests__/typebox-schema.test.ts
+++ b/src/__tests__/typebox-schema.test.ts
@@ -51,6 +51,15 @@ describe("OzNonEnumerableAclOptionsTB schema", () => {
     };
     expect(isTypeOfTB(invalid, OzNonEnumerableAclOptionsTB)).toBe(false);
   });
+
+  it("rejects zero or negative eventBatchSize", () => {
+    expect(isTypeOfTB({ eventBatchSize: 0 }, OzNonEnumerableAclOptionsTB)).toBe(false);
+    expect(isTypeOfTB({ eventBatchSize: -1 }, OzNonEnumerableAclOptionsTB)).toBe(false);
+  });
+
+  it("rejects non-integer eventBatchSize", () => {
+    expect(isTypeOfTB({ eventBatchSize: 1.5 }, OzNonEnumerableAclOptionsTB)).toBe(false);
+  });
 });
 
 describe("ProxyContractEntryTB with ozNonEnumerableAclOptions", () => {

--- a/src/cache-provider.ts
+++ b/src/cache-provider.ts
@@ -199,6 +199,9 @@ export function saveEventScanToCache(address: string, roleHolders: RoleHoldersMa
 }
 
 export function flushCacheUpdates(): void {
+  if (g_cacheDisabled) {
+    return;
+  }
   ensureCacheDirectory();
 
   if (g_creationBlockCacheDirty && g_creationBlockCache) {

--- a/src/cache-provider.ts
+++ b/src/cache-provider.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { log } from "./logger";
+
+const CACHE_VERSION = "1.0.0";
+const CACHE_DIR_NAME = "cache";
+const CREATION_BLOCKS_FILE = "creation-blocks.json";
+const EVENT_SCANS_FILE = "event-scans.json";
+
+export interface ContractCreationCacheEntry {
+  blockNumber: number;
+  txHash: string;
+  deployer: string;
+}
+
+export interface EventScanCacheEntry {
+  roleHolders: Record<string, string[]>; // role -> holders array (serialized from Map<string, Set<string>>)
+  lastScannedBlock: number;
+}
+
+interface CreationBlocksCache {
+  version: string;
+  entries: Record<string, ContractCreationCacheEntry>;
+}
+
+interface EventScansCache {
+  version: string;
+  entries: Record<string, EventScanCacheEntry>;
+}
+
+let g_creationBlockCache: CreationBlocksCache | null = null;
+let g_eventScanCache: EventScansCache | null = null;
+let g_cacheDirectory: string | null = null;
+let g_creationBlockCacheDirty = false;
+let g_eventScanCacheDirty = false;
+
+export type RoleHoldersMap = Map<string, Set<string>>;
+
+export function initCacheDirectory(configPath: string): void {
+  g_cacheDirectory = path.join(path.dirname(configPath), CACHE_DIR_NAME);
+}
+
+function getCacheDirectory(): string {
+  if (!g_cacheDirectory) {
+    throw new Error("Cache directory not initialized. Call initCacheDirectory() first.");
+  }
+  return g_cacheDirectory;
+}
+
+function ensureCacheDirectory(): void {
+  const cacheDirectory = getCacheDirectory();
+  if (!fs.existsSync(cacheDirectory)) {
+    fs.mkdirSync(cacheDirectory, { recursive: true });
+  }
+}
+
+function loadCreationBlocksCache(): CreationBlocksCache {
+  if (g_creationBlockCache) {
+    return g_creationBlockCache;
+  }
+
+  const cacheFile = path.join(getCacheDirectory(), CREATION_BLOCKS_FILE);
+  if (fs.existsSync(cacheFile)) {
+    try {
+      const content = fs.readFileSync(cacheFile, "utf8");
+      const cache = JSON.parse(content) as CreationBlocksCache;
+      if (cache.version === CACHE_VERSION) {
+        g_creationBlockCache = cache;
+        return g_creationBlockCache;
+      }
+      log(`  Cache version mismatch for creation blocks, starting fresh`);
+    } catch {
+      log(`  Failed to read creation blocks cache, starting fresh`);
+    }
+  }
+
+  g_creationBlockCache = { version: CACHE_VERSION, entries: {} };
+  return g_creationBlockCache;
+}
+
+function loadEventScansCache(): EventScansCache {
+  if (g_eventScanCache) {
+    return g_eventScanCache;
+  }
+
+  const cacheFile = path.join(getCacheDirectory(), EVENT_SCANS_FILE);
+  if (fs.existsSync(cacheFile)) {
+    try {
+      const content = fs.readFileSync(cacheFile, "utf8");
+      const cache = JSON.parse(content) as EventScansCache;
+      if (cache.version === CACHE_VERSION) {
+        g_eventScanCache = cache;
+        return g_eventScanCache;
+      }
+      log(`  Cache version mismatch for event scans, starting fresh`);
+    } catch {
+      log(`  Failed to read event scans cache, starting fresh`);
+    }
+  }
+
+  g_eventScanCache = { version: CACHE_VERSION, entries: {} };
+  return g_eventScanCache;
+}
+
+export function loadCreationBlockFromCache(address: string): ContractCreationCacheEntry | null {
+  const cache = loadCreationBlocksCache();
+  const normalizedAddress = address.toLowerCase();
+  return cache.entries[normalizedAddress] ?? null;
+}
+
+export function saveCreationBlockToCache(address: string, blockNumber: number, txHash: string, deployer: string): void {
+  const cache = loadCreationBlocksCache();
+  const normalizedAddress = address.toLowerCase();
+  cache.entries[normalizedAddress] = { blockNumber, txHash, deployer };
+  g_creationBlockCacheDirty = true;
+}
+
+export function loadEventScanFromCache(address: string, currentBlock: number): RoleHoldersMap | null {
+  const cache = loadEventScansCache();
+  const normalizedAddress = address.toLowerCase();
+  const entry = cache.entries[normalizedAddress];
+
+  if (!entry) {
+    return null;
+  }
+
+  // Only use cache if we've scanned up to the current block
+  if (entry.lastScannedBlock < currentBlock) {
+    return null;
+  }
+
+  // Convert serialized format back to Map<string, Set<string>>
+  const roleHolders: RoleHoldersMap = new Map();
+  for (const [role, holders] of Object.entries(entry.roleHolders)) {
+    roleHolders.set(role, new Set(holders));
+  }
+  return roleHolders;
+}
+
+export function getLastScannedBlock(address: string): number | null {
+  const cache = loadEventScansCache();
+  const normalizedAddress = address.toLowerCase();
+  const entry = cache.entries[normalizedAddress];
+  return entry?.lastScannedBlock ?? null;
+}
+
+export function getCachedRoleHolders(address: string): RoleHoldersMap | null {
+  const cache = loadEventScansCache();
+  const normalizedAddress = address.toLowerCase();
+  const entry = cache.entries[normalizedAddress];
+
+  if (!entry) {
+    return null;
+  }
+
+  const roleHolders: RoleHoldersMap = new Map();
+  for (const [role, holders] of Object.entries(entry.roleHolders)) {
+    roleHolders.set(role, new Set(holders));
+  }
+  return roleHolders;
+}
+
+export function saveEventScanToCache(address: string, roleHolders: RoleHoldersMap, lastScannedBlock: number): void {
+  const cache = loadEventScansCache();
+  const normalizedAddress = address.toLowerCase();
+
+  // Convert Map<string, Set<string>> to serializable format
+  const serializedRoleHolders: Record<string, string[]> = {};
+  for (const [role, holders] of roleHolders) {
+    serializedRoleHolders[role] = [...holders];
+  }
+
+  cache.entries[normalizedAddress] = {
+    roleHolders: serializedRoleHolders,
+    lastScannedBlock,
+  };
+  g_eventScanCacheDirty = true;
+}
+
+export function flushCacheUpdates(): void {
+  ensureCacheDirectory();
+
+  if (g_creationBlockCacheDirty && g_creationBlockCache) {
+    const cacheFile = path.join(getCacheDirectory(), CREATION_BLOCKS_FILE);
+    fs.writeFileSync(cacheFile, JSON.stringify(g_creationBlockCache, null, 2));
+    g_creationBlockCacheDirty = false;
+    log(`  Saved creation blocks cache`);
+  }
+
+  if (g_eventScanCacheDirty && g_eventScanCache) {
+    const cacheFile = path.join(getCacheDirectory(), EVENT_SCANS_FILE);
+    fs.writeFileSync(cacheFile, JSON.stringify(g_eventScanCache, null, 2));
+    g_eventScanCacheDirty = false;
+    log(`  Saved event scans cache`);
+  }
+}
+
+export function clearCacheState(): void {
+  g_creationBlockCache = null;
+  g_eventScanCache = null;
+  g_cacheDirectory = null;
+  g_creationBlockCacheDirty = false;
+  g_eventScanCacheDirty = false;
+}

--- a/src/clear-cache.ts
+++ b/src/clear-cache.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+
+import { program } from "commander";
+
+import { clearCacheDirectory, initCacheDirectory } from "./cache-provider";
+import { log, logErrorAndExit } from "./logger";
+
+program.argument("<config-path>", "path to .yaml state config file").allowExcessArguments(false).parse();
+
+const configPath = program.args[0];
+
+if (!configPath) {
+  logErrorAndExit("Config path is required");
+}
+
+const absoluteConfigPath = path.isAbsolute(configPath) ? configPath : path.resolve(process.cwd(), configPath);
+
+log(`Clearing cache for config: ${absoluteConfigPath}`);
+
+// Initialize cache directory (with cache enabled so we can clear it)
+initCacheDirectory(absoluteConfigPath, { disabled: false });
+
+// Clear the cache
+clearCacheDirectory();
+
+log("Cache cleared successfully");

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -23,7 +23,6 @@ export function parseCmdLineArguments() {
     .option("--generate", "generate a populated config from the seed one")
     .option("--update-abi", "download all ABIs replacing existing files")
     .option("--cache", "enable caching for exhaustive ACL checks")
-    .option("--clear-cache", "clear the cache directory before running")
     .parse();
 
   const configPath = program.args[0];
@@ -52,6 +51,5 @@ export function parseCmdLineArguments() {
     generate: options.generate,
     updateAbi: options.updateAbi,
     cacheEnabled: options.cache === true, // --cache explicitly enables caching
-    clearCache: options.clearCache,
   };
 }

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -22,7 +22,7 @@ export function parseCmdLineArguments() {
     )
     .option("--generate", "generate a populated config from the seed one")
     .option("--update-abi", "download all ABIs replacing existing files")
-    .option("--no-cache", "disable caching for exhaustive ACL checks")
+    .option("--cache", "enable caching for exhaustive ACL checks")
     .option("--clear-cache", "clear the cache directory before running")
     .parse();
 
@@ -51,7 +51,7 @@ export function parseCmdLineArguments() {
     checkOnlyCmdArg: options.only,
     generate: options.generate,
     updateAbi: options.updateAbi,
-    noCache: options.cache === false, // --no-cache sets options.cache to false
+    cacheEnabled: options.cache === true, // --cache explicitly enables caching
     clearCache: options.clearCache,
   };
 }

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -22,6 +22,8 @@ export function parseCmdLineArguments() {
     )
     .option("--generate", "generate a populated config from the seed one")
     .option("--update-abi", "download all ABIs replacing existing files")
+    .option("--no-cache", "disable caching for exhaustive ACL checks")
+    .option("--clear-cache", "clear the cache directory before running")
     .parse();
 
   const configPath = program.args[0];
@@ -49,5 +51,7 @@ export function parseCmdLineArguments() {
     checkOnlyCmdArg: options.only,
     generate: options.generate,
     updateAbi: options.updateAbi,
+    noCache: options.cache === false, // --no-cache sets options.cache to false
+    clearCache: options.clearCache,
   };
 }

--- a/src/event-scanner.ts
+++ b/src/event-scanner.ts
@@ -1,0 +1,153 @@
+import { id as ethersId, JsonRpcProvider, Log } from "ethers";
+
+import { RoleHoldersMap } from "./cache-provider";
+import { log } from "./logger";
+
+// OZ AccessControl event signatures
+// event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+// event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+export const ROLE_GRANTED_TOPIC = ethersId("RoleGranted(bytes32,address,address)");
+export const ROLE_REVOKED_TOPIC = ethersId("RoleRevoked(bytes32,address,address)");
+
+export interface RoleEvent {
+  role: string;
+  account: string;
+  sender: string;
+  blockNumber: number;
+  transactionHash: string;
+  eventType: "granted" | "revoked";
+}
+
+export interface EventScanOptions {
+  batchSize: number;
+  fromBlock: number;
+  toBlock: number | "latest";
+}
+
+export interface EventScanResult {
+  events: RoleEvent[];
+  toBlock: number;
+}
+
+export function parseRoleEvent(eventLog: Log): RoleEvent {
+  const isGrant = eventLog.topics[0] === ROLE_GRANTED_TOPIC;
+
+  // topics[0] = event signature
+  // topics[1] = role (bytes32, indexed)
+  // topics[2] = account (address, indexed)
+  // topics[3] = sender (address, indexed)
+  const role = eventLog.topics[1];
+  const account = "0x" + eventLog.topics[2].slice(26); // Extract address from 32-byte topic
+  const sender = "0x" + eventLog.topics[3].slice(26);
+
+  return {
+    role,
+    account: account.toLowerCase(),
+    sender: sender.toLowerCase(),
+    blockNumber: eventLog.blockNumber,
+    transactionHash: eventLog.transactionHash,
+    eventType: isGrant ? "granted" : "revoked",
+  };
+}
+
+export function buildRoleHoldersFromEvents(events: RoleEvent[]): RoleHoldersMap {
+  const roleHolders: RoleHoldersMap = new Map();
+
+  // Sort events by block number to process chronologically
+  // For events in the same block, maintain original order (log index)
+  const sortedEvents = [...events].sort((a, b) => a.blockNumber - b.blockNumber);
+
+  for (const event of sortedEvents) {
+    if (!roleHolders.has(event.role)) {
+      roleHolders.set(event.role, new Set());
+    }
+
+    const holders = roleHolders.get(event.role)!;
+
+    if (event.eventType === "granted") {
+      holders.add(event.account);
+    } else {
+      holders.delete(event.account);
+    }
+  }
+
+  return roleHolders;
+}
+
+export function mergeRoleHolders(base: RoleHoldersMap, newEvents: RoleEvent[]): RoleHoldersMap {
+  // Clone the base map
+  const result: RoleHoldersMap = new Map();
+  for (const [role, holders] of base) {
+    result.set(role, new Set(holders));
+  }
+
+  // Apply new events
+  const sortedEvents = [...newEvents].sort((a, b) => a.blockNumber - b.blockNumber);
+
+  for (const event of sortedEvents) {
+    if (!result.has(event.role)) {
+      result.set(event.role, new Set());
+    }
+
+    const holders = result.get(event.role)!;
+
+    if (event.eventType === "granted") {
+      holders.add(event.account);
+    } else {
+      holders.delete(event.account);
+    }
+  }
+
+  return result;
+}
+
+export async function scanRoleEvents(
+  provider: JsonRpcProvider,
+  contractAddress: string,
+  options: EventScanOptions,
+): Promise<EventScanResult> {
+  const { batchSize, fromBlock } = options;
+  const toBlock = options.toBlock === "latest" ? await provider.getBlockNumber() : options.toBlock;
+
+  const allEvents: RoleEvent[] = [];
+  let processedBatches = 0;
+  const totalBatches = Math.ceil((toBlock - fromBlock + 1) / batchSize);
+
+  // Batch fetch events to avoid RPC limits
+  for (let start = fromBlock; start <= toBlock; start += batchSize) {
+    const end = Math.min(start + batchSize - 1, toBlock);
+    processedBatches++;
+
+    if (totalBatches > 1) {
+      log(`    Scanning blocks ${start}-${end} (batch ${processedBatches}/${totalBatches})...`);
+    }
+
+    try {
+      const logs = await provider.getLogs({
+        address: contractAddress,
+        topics: [[ROLE_GRANTED_TOPIC, ROLE_REVOKED_TOPIC]],
+        fromBlock: start,
+        toBlock: end,
+      });
+
+      for (const eventLog of logs) {
+        allEvents.push(parseRoleEvent(eventLog));
+      }
+    } catch (error) {
+      // If batch is too large, try smaller batches
+      if (batchSize > 1000 && (error as Error).message?.includes("query returned more than")) {
+        log(`    Batch too large, retrying with smaller batch size...`);
+        const smallerResult = await scanRoleEvents(provider, contractAddress, {
+          batchSize: Math.floor(batchSize / 2),
+          fromBlock: start,
+          toBlock: end,
+        });
+        allEvents.push(...smallerResult.events);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return { events: allEvents, toBlock };
+}

--- a/src/explorers/etherscan.ts
+++ b/src/explorers/etherscan.ts
@@ -5,7 +5,7 @@ import {
   httpGetAsync,
   loadContractInfo,
 } from "src/explorer-provider";
-import { log, logErrorAndExit } from "src/logger";
+import { log, logError, logErrorAndExit } from "src/logger";
 import {
   Abi,
   CommonResponseOkResult,
@@ -14,6 +14,21 @@ import {
   ResponseBad,
   ResponseOk,
 } from "src/types";
+
+export interface ContractCreationResult {
+  txHash: string;
+  deployer: string;
+}
+
+interface ContractCreationResponse {
+  status: string;
+  message: string;
+  result: Array<{
+    contractAddress: string;
+    contractCreator: string;
+    txHash: string;
+  }>;
+}
 
 export class EtherscanHandler implements IExplorerHandler {
   requestWithRateLimit: RateLimitHandler = etherRateLimitHandler;
@@ -78,4 +93,67 @@ async function etherGetContractInfoCallback(
   };
 
   return contractInfo;
+}
+
+function buildContractCreationApiUrl(
+  address: string,
+  explorerHostname: string,
+  explorerKey?: string,
+  chainId?: number | string,
+): string {
+  const isEtherscan = explorerHostname.includes("etherscan.io");
+  let url: string;
+
+  if (isEtherscan) {
+    const chainIdNumber = typeof chainId === "string" ? Number(chainId) : chainId;
+    if (typeof chainIdNumber !== "number" || Number.isNaN(chainIdNumber)) {
+      logErrorAndExit(`chainId is required for Etherscan API`);
+    }
+    url = `https://api.etherscan.io/v2/api?chainId=${chainIdNumber}&module=contract&action=getcontractcreation&contractaddresses=${address}`;
+  } else {
+    url = `https://${explorerHostname}/api?module=contract&action=getcontractcreation&contractaddresses=${address}`;
+  }
+
+  if (explorerKey) {
+    url = `${url}&apikey=${explorerKey}`;
+  }
+
+  return url;
+}
+
+export async function getContractCreation(
+  address: string,
+  explorerHostname: string,
+  explorerKey?: string,
+  chainId?: number | string,
+): Promise<ContractCreationResult | null> {
+  const url = buildContractCreationApiUrl(address, explorerHostname, explorerKey, chainId);
+
+  try {
+    let response = await httpGetAsync<ContractCreationResponse>(url);
+
+    // Handle rate limiting
+    if (
+      response.status === "0" &&
+      (response.message?.includes("rate limit") || response.result?.toString().includes("rate limit"))
+    ) {
+      log(`  Reached rate limit, waiting ${RATE_LIMIT_TIMEOUT_MS}ms...`);
+      await sleep(RATE_LIMIT_TIMEOUT_MS);
+      response = await httpGetAsync<ContractCreationResponse>(url);
+    }
+
+    if (response.status !== "1" || !Array.isArray(response.result) || response.result.length === 0) {
+      logError(`Failed to get contract creation info: ${response.message || "Unknown error"}`);
+      return null;
+    }
+
+    const result = response.result[0];
+    return {
+      txHash: result.txHash,
+      deployer: result.contractCreator,
+    };
+  } catch (error) {
+    logError(`Error fetching contract creation info: ${(error as Error).message}`);
+    return null;
+  }
 }

--- a/src/section-validators/contract.ts
+++ b/src/section-validators/contract.ts
@@ -8,13 +8,13 @@ import { CheckLevel, clearErrorContext, needCheck, SectionValidatorBase, setErro
 import { ChecksSectionValidator } from "./checks";
 import { ImplementationChecksSectionValidator } from "./implementation-checks";
 import { OzAclSectionValidator } from "./oz-acl";
-import { OzNonEnumerableAclSectionValidator } from "./oz-non-enumerable-acl";
+import { ExplorerInfo, OzNonEnumerableAclSectionValidator } from "./oz-non-enumerable-acl";
 import { ProxyCheckSectionValidator } from "./proxy-check";
 
 export class ContractSectionValidator {
   private map: Map<EntryField, SectionValidatorBase> = new Map();
 
-  constructor(provider: JsonRpcProvider) {
+  constructor(provider: JsonRpcProvider, explorerInfo?: ExplorerInfo) {
     const sections = [
       EntryField.checks,
       EntryField.proxyChecks,
@@ -33,7 +33,7 @@ export class ContractSectionValidator {
           break;
         }
         case EntryField.ozNonEnumerableAcl: {
-          this.map.set(section, new OzNonEnumerableAclSectionValidator(provider));
+          this.map.set(section, new OzNonEnumerableAclSectionValidator(provider, explorerInfo));
           break;
         }
         case EntryField.implementationChecks: {

--- a/src/section-validators/oz-non-enumerable-acl.ts
+++ b/src/section-validators/oz-non-enumerable-acl.ts
@@ -1,24 +1,50 @@
 import { assert } from "chai";
-import { JsonRpcProvider } from "ethers";
+import { Contract, JsonRpcProvider } from "ethers";
 
 import { loadAbiFromFile } from "src/abi-provider";
+import {
+  flushCacheUpdates,
+  getCachedRoleHolders,
+  getLastScannedBlock,
+  RoleHoldersMap,
+  saveEventScanToCache,
+} from "src/cache-provider";
 import { EntryField } from "src/common";
-import { loadContract } from "src/explorer-provider";
+import { buildRoleHoldersFromEvents, mergeRoleHolders, scanRoleEvents } from "src/event-scanner";
+import { getContractCreationBlock, loadContract } from "src/explorer-provider";
 import { log, LogCommand, logHeader2, WARNING_MARK } from "src/logger";
 import { ContractEntry, isTypeOfTB, ProxyContractEntryTB } from "src/typebox";
 import { Abi } from "src/types";
 
 import { incChecks, incErrors, SectionValidatorBase, setErrorContext } from "./base";
 
+const DEFAULT_EVENT_BATCH_SIZE = 5000;
+
+export interface ExplorerInfo {
+  hostname: string;
+  key?: string;
+  chainId?: number | string;
+}
+
 export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
-  constructor(provider: JsonRpcProvider) {
+  private explorerInfo?: ExplorerInfo;
+
+  constructor(provider: JsonRpcProvider, explorerInfo?: ExplorerInfo) {
     super(provider, EntryField.ozNonEnumerableAcl);
+    this.explorerInfo = explorerInfo;
   }
+
   override async validateSection(contractEntry: ContractEntry) {
-    if (contractEntry.ozNonEnumerableAcl) {
-      logHeader2(this.sectionName);
-      await this._validate(contractEntry);
+    if (!contractEntry.ozNonEnumerableAcl) {
+      return;
     }
+
+    logHeader2(this.sectionName);
+
+    const options = contractEntry.ozNonEnumerableAclOptions;
+    const isExhaustive = options?.exhaustive === true;
+
+    await (isExhaustive ? this._validateExhaustive(contractEntry) : this._validate(contractEntry));
   }
 
   /**
@@ -43,9 +69,12 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
     return loadAbiFromFile(name, address);
   }
 
+  /**
+   * Non-exhaustive validation: only checks configured role-holder pairs
+   */
   protected async _validate(contractEntry: ContractEntry) {
     const abi = this._loadAbiWithImplementationFallback(contractEntry);
-    const contract = loadContract(contractEntry.address, abi, this.provider); //TODO to move out from this method
+    const contract = loadContract(contractEntry.address, abi, this.provider);
 
     log(
       `${WARNING_MARK}: Non-enumerable OZ Acl means it is impossible to check absence of an arbitrary role holder ` +
@@ -94,6 +123,193 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Exhaustive validation: scans events to detect ALL role holders
+   */
+  private async _validateExhaustive(contractEntry: ContractEntry) {
+    const { address } = contractEntry;
+    const eventAddress = address; // Events are emitted from proxy address where storage lives
+    const batchSize = contractEntry.ozNonEnumerableAclOptions?.eventBatchSize ?? DEFAULT_EVENT_BATCH_SIZE;
+
+    log(`  Performing exhaustive ACL check via event scanning...`);
+
+    // Check if we have explorer info for fetching creation block
+    if (!this.explorerInfo?.hostname) {
+      log(
+        `${WARNING_MARK}: No explorer configured. Cannot perform exhaustive check. Falling back to non-exhaustive check.`,
+      );
+      await this._validate(contractEntry);
+      return;
+    }
+
+    // Get contract creation block
+    const creationInfo = await getContractCreationBlock(
+      eventAddress,
+      this.explorerInfo.hostname,
+      this.provider,
+      this.explorerInfo.key,
+      this.explorerInfo.chainId,
+    );
+
+    if (!creationInfo) {
+      log(`${WARNING_MARK}: Could not determine contract creation block. Falling back to non-exhaustive check.`);
+      await this._validate(contractEntry);
+      return;
+    }
+
+    log(`  Contract deployed at block ${creationInfo.blockNumber}`);
+
+    // Get current block
+    const currentBlock = await this.provider.getBlockNumber();
+
+    // Check cache and perform incremental scan if needed
+    let roleHolders: RoleHoldersMap;
+    const lastScannedBlock = getLastScannedBlock(eventAddress);
+    const cachedRoleHolders = getCachedRoleHolders(eventAddress);
+
+    if (cachedRoleHolders && lastScannedBlock !== null && lastScannedBlock >= currentBlock) {
+      log(`  Using cached event scan results (up to block ${lastScannedBlock})`);
+      roleHolders = cachedRoleHolders;
+    } else if (cachedRoleHolders && lastScannedBlock !== null && lastScannedBlock >= creationInfo.blockNumber) {
+      // Incremental scan from last scanned block
+      log(`  Performing incremental scan from block ${lastScannedBlock + 1} to ${currentBlock}...`);
+      const { events, toBlock } = await scanRoleEvents(this.provider, eventAddress, {
+        batchSize,
+        fromBlock: lastScannedBlock + 1,
+        toBlock: currentBlock,
+      });
+      log(`  Found ${events.length} new role events`);
+
+      roleHolders = mergeRoleHolders(cachedRoleHolders, events);
+      saveEventScanToCache(eventAddress, roleHolders, toBlock);
+      flushCacheUpdates();
+    } else {
+      // Full scan from deployment
+      log(`  Scanning events from block ${creationInfo.blockNumber} to ${currentBlock}...`);
+      const { events, toBlock } = await scanRoleEvents(this.provider, eventAddress, {
+        batchSize,
+        fromBlock: creationInfo.blockNumber,
+        toBlock: currentBlock,
+      });
+      log(`  Found ${events.length} role events`);
+
+      roleHolders = buildRoleHoldersFromEvents(events);
+      saveEventScanToCache(eventAddress, roleHolders, toBlock);
+      flushCacheUpdates();
+    }
+
+    // Compare with config
+    await this._compareRoleHolders(contractEntry, roleHolders);
+  }
+
+  /**
+   * Compare actual role holders (from events) against configured role holders
+   */
+  private async _compareRoleHolders(contractEntry: ContractEntry, actualRoleHolders: RoleHoldersMap) {
+    const abi = this._loadAbiWithImplementationFallback(contractEntry);
+    const contract = loadContract(contractEntry.address, abi, this.provider);
+
+    const expectedRoles = contractEntry.ozNonEnumerableAcl!;
+    const allConfiguredRoles = new Set(Object.keys(expectedRoles));
+
+    // Check each configured role
+    for (const role of allConfiguredRoles) {
+      const expectedHolders = new Set(expectedRoles[role].map((h) => h.toLowerCase()));
+      const actualHolders = actualRoleHolders.get(role) ?? new Set();
+
+      log(`  Role: ${role}`);
+      log(`    Expected holders: ${expectedRoles[role].length}, Actual holders from events: ${actualHolders.size}`);
+
+      // Check expected holders are present
+      for (const expectedHolder of expectedHolders) {
+        await this._verifyHolderHasRole(contract, role, expectedHolder, true);
+      }
+
+      // Check for UNEXPECTED holders (the key feature!)
+      for (const actualHolder of actualHolders) {
+        if (!expectedHolders.has(actualHolder)) {
+          await this._checkUnexpectedHolder(contract, role, actualHolder);
+        }
+      }
+    }
+
+    // Check for roles in events but not in config
+    for (const [role, holders] of actualRoleHolders) {
+      if (!allConfiguredRoles.has(role) && holders.size > 0) {
+        log(`${WARNING_MARK}: Unconfigured role ${role} has ${holders.size} holder(s):`);
+        for (const holder of holders) {
+          // Verify on-chain
+          const hasRole = await this._checkHasRole(contract, role, holder);
+          if (hasRole) {
+            log(`    - ${holder} (confirmed on-chain)`);
+            incChecks();
+            incErrors(`Unconfigured role ${role} has unexpected holder: ${holder}`);
+          }
+        }
+      }
+    }
+  }
+
+  private async _verifyHolderHasRole(
+    contract: Contract,
+    role: string,
+    holder: string,
+    expected: boolean,
+  ): Promise<void> {
+    incChecks();
+    const methodName = `.hasRole(${role}, ${holder})`;
+    const logHandle = new LogCommand(methodName);
+    setErrorContext({ method: methodName });
+
+    try {
+      const hasRole = await contract.getFunction("hasRole").staticCall(role, holder);
+      if (hasRole === expected) {
+        logHandle.success(`${hasRole}`);
+      } else {
+        const errorMessage = expected
+          ? `Expected holder ${holder} to have role but hasRole returned false`
+          : `Expected holder ${holder} to NOT have role but hasRole returned true`;
+        logHandle.failure(errorMessage);
+        incErrors(errorMessage);
+      }
+    } catch (error) {
+      const errorMessage = `REVERTED with: ${(error as Error).message}`;
+      logHandle.failure(errorMessage);
+      incErrors(errorMessage);
+    }
+  }
+
+  private async _checkUnexpectedHolder(contract: Contract, role: string, holder: string): Promise<void> {
+    incChecks();
+    const methodName = `UNEXPECTED .hasRole(${role}, ${holder})`;
+    const logHandle = new LogCommand(methodName);
+    setErrorContext({ method: methodName });
+
+    try {
+      const hasRole = await contract.getFunction("hasRole").staticCall(role, holder);
+      if (hasRole) {
+        const errorMessage = `UNEXPECTED role holder found: ${holder} has role ${role}`;
+        logHandle.failure(errorMessage);
+        incErrors(errorMessage);
+      } else {
+        // Role was granted but later revoked - not an error
+        logHandle.success(`false (role was revoked)`);
+      }
+    } catch (error) {
+      const errorMessage = `REVERTED with: ${(error as Error).message}`;
+      logHandle.failure(errorMessage);
+      incErrors(errorMessage);
+    }
+  }
+
+  private async _checkHasRole(contract: Contract, role: string, holder: string): Promise<boolean> {
+    try {
+      return await contract.getFunction("hasRole").staticCall(role, holder);
+    } catch {
+      return false;
     }
   }
 }

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -12,7 +12,7 @@ import * as YAML from "yaml";
 
 import { checkAllAbi, flushAbiUpdates, renameAllAbiToLowerCase, resetAbiModeCache } from "./abi-provider";
 import { doGenerateBoilerplate } from "./boilerplate-generator";
-import { clearCacheDirectory, flushCacheUpdates, initCacheDirectory } from "./cache-provider";
+import { flushCacheUpdates, initCacheDirectory } from "./cache-provider";
 import { parseCmdLineArguments } from "./cli-parser";
 import { printError, readUrlOrFromEnvironment } from "./common";
 import { loadContractInfoFromExplorer } from "./explorer-provider";
@@ -113,11 +113,6 @@ function validateJsonWithSchema<T extends TSchema>(
 async function doChecks(jsonDocument: EntireDocument) {
   // Initialize cache directory for event scanning (disabled by default, enabled with --cache)
   initCacheDirectory(g_Arguments.configPath, { disabled: !g_Arguments.cacheEnabled });
-
-  // Clear cache if requested
-  if (g_Arguments.clearCache) {
-    clearCacheDirectory();
-  }
 
   for (const [sectionTitle, section] of Object.entries(jsonDocument)) {
     if (isTypeOfTB(section, NetworkSectionTB)) await checkNetworkSection(sectionTitle, section);

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -111,8 +111,8 @@ function validateJsonWithSchema<T extends TSchema>(
 }
 
 async function doChecks(jsonDocument: EntireDocument) {
-  // Initialize cache directory for event scanning
-  initCacheDirectory(g_Arguments.configPath, { disabled: g_Arguments.noCache });
+  // Initialize cache directory for event scanning (disabled by default, enabled with --cache)
+  initCacheDirectory(g_Arguments.configPath, { disabled: !g_Arguments.cacheEnabled });
 
   // Clear cache if requested
   if (g_Arguments.clearCache) {

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -12,7 +12,7 @@ import * as YAML from "yaml";
 
 import { checkAllAbi, flushAbiUpdates, renameAllAbiToLowerCase, resetAbiModeCache } from "./abi-provider";
 import { doGenerateBoilerplate } from "./boilerplate-generator";
-import { flushCacheUpdates, initCacheDirectory } from "./cache-provider";
+import { clearCacheDirectory, flushCacheUpdates, initCacheDirectory } from "./cache-provider";
 import { parseCmdLineArguments } from "./cli-parser";
 import { printError, readUrlOrFromEnvironment } from "./common";
 import { loadContractInfoFromExplorer } from "./explorer-provider";
@@ -112,7 +112,12 @@ function validateJsonWithSchema<T extends TSchema>(
 
 async function doChecks(jsonDocument: EntireDocument) {
   // Initialize cache directory for event scanning
-  initCacheDirectory(g_Arguments.configPath);
+  initCacheDirectory(g_Arguments.configPath, { disabled: g_Arguments.noCache });
+
+  // Clear cache if requested
+  if (g_Arguments.clearCache) {
+    clearCacheDirectory();
+  }
 
   for (const [sectionTitle, section] of Object.entries(jsonDocument)) {
     if (isTypeOfTB(section, NetworkSectionTB)) await checkNetworkSection(sectionTitle, section);

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -42,6 +42,17 @@ export function isTypeOfTB<T extends TSchema>(value: unknown, schema: T): value 
 
 const OzNonEnumerableAclTB = Type.Readonly(Type.Record(EthereumStringTB, EthereumStringArrayTB));
 
+export const OzNonEnumerableAclOptionsTB = Type.Readonly(
+  Type.Object(
+    {
+      exhaustive: Type.Optional(Type.Boolean()),
+      eventBatchSize: Type.Optional(Type.Number()),
+    },
+    { additionalProperties: false },
+  ),
+);
+export type OzNonEnumerableAclOptions = Static<typeof OzNonEnumerableAclOptionsTB>;
+
 export const PlainValueTB = Type.Readonly(Type.Union([Type.Null(), Type.String(), Type.Boolean(), Type.Number()]));
 export const PlainValueArrayTB = Type.Readonly(Type.Array(PlainValueTB));
 // Support deeper nesting for complex tuple returns (e.g., Safe Harbor Agreement details)
@@ -156,6 +167,7 @@ const RegularContractEntryTB = Type.Readonly(
       name: Type.String(),
       checks: RegularChecksTB,
       ozNonEnumerableAcl: Type.Optional(OzNonEnumerableAclTB),
+      ozNonEnumerableAclOptions: Type.Optional(OzNonEnumerableAclOptionsTB),
       ozAcl: Type.Optional(OzAclChecksTB),
     },
     { additionalProperties: false },

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -46,7 +46,7 @@ export const OzNonEnumerableAclOptionsTB = Type.Readonly(
   Type.Object(
     {
       exhaustive: Type.Optional(Type.Boolean()),
-      eventBatchSize: Type.Optional(Type.Number()),
+      eventBatchSize: Type.Optional(Type.Integer({ minimum: 1 })),
     },
     { additionalProperties: false },
   ),

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,15 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      src: path.resolve(import.meta.dirname, "./src"),
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,6 +230,167 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/aix-ppc64@npm:0.21.5"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm@npm:0.21.5"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-arm64@npm:0.21.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-arm64@npm:0.21.5"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm64@npm:0.21.5"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ia32@npm:0.21.5"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-mips64el@npm:0.21.5"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-riscv64@npm:0.21.5"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-x64@npm:0.21.5"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/netbsd-x64@npm:0.21.5"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/openbsd-x64@npm:0.21.5"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/sunos-x64@npm:0.21.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-arm64@npm:0.21.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-ia32@npm:0.21.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.1
   resolution: "@eslint-community/eslint-utils@npm:4.4.1"
@@ -542,6 +703,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  dependencies:
+    "@isaacs/balanced-match": "npm:^4.0.1"
+  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
+  languageName: node
+  linkType: hard
+
+"@isaacs/fs-minipass@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@isaacs/fs-minipass@npm:4.0.1"
+  dependencies:
+    minipass: "npm:^7.0.4"
+  checksum: 10c0/c25b6dc1598790d5b55c0947a9b7d111cfa92594db5296c3b907e2f533c033666f692a3939eadac17b1c7c40d362d0b0635dc874cbfe3e70db7c2b07cc97a5d2
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
@@ -553,6 +739,13 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
   languageName: node
   linkType: hard
 
@@ -616,10 +809,207 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/agent@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@npmcli/agent@npm:4.0.0"
+  dependencies:
+    agent-base: "npm:^7.1.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.1"
+    lru-cache: "npm:^11.2.1"
+    socks-proxy-agent: "npm:^8.0.3"
+  checksum: 10c0/f7b5ce0f3dd42c3f8c6546e8433573d8049f67ef11ec22aa4704bc41483122f68bf97752e06302c455ead667af5cb753e6a09bff06632bc465c1cfd4c4b75a53
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@npmcli/fs@npm:5.0.0"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10c0/26e376d780f60ff16e874a0ac9bc3399186846baae0b6e1352286385ac134d900cc5dafaded77f38d77f86898fc923ae1cee9d7399f0275b1aa24878915d722b
+  languageName: node
+  linkType: hard
+
 "@pkgr/core@npm:^0.1.0":
   version: 0.1.1
   resolution: "@pkgr/core@npm:0.1.1"
   checksum: 10c0/3f7536bc7f57320ab2cf96f8973664bef624710c403357429fbf680a5c3b4843c1dbd389bb43daa6b1f6f1f007bb082f5abcb76bb2b5dc9f421647743b71d3d8
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm-eabi@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.55.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-android-arm64@npm:4.55.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.55.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-darwin-x64@npm:4.55.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.55.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.55.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.55.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.55.1"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.55.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.55.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.55.1"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.55.1"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.55.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.55.1"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.55.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.55.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.55.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.55.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.55.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.55.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.55.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.55.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.55.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.55.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.55.1":
+  version: 4.55.1
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.55.1"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -685,6 +1075,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/4b7b561f195f779d07f973801a9f15d77cd58ceb67e817459688b11cc735288d30de050f445c91f4cd2c007fa86824e59a6e3cde602d150b828c4474f6e67be5
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
@@ -884,6 +1281,87 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/expect@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/98d1cf02917316bebef9e4720723e38298a1c12b3c8f3a81f259bb822de4288edf594e69ff64f0b88afbda6d04d7a4f0c2f720f3fec16b4c45f5e2669f09fdbb
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/mocker@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.12"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/f734490d8d1206a7f44dfdfca459282f5921d73efa72935bb1dc45307578defd38a4131b14853316373ec364cbe910dbc74594ed4137e0da35aa4d9bb716f190
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:2.1.9, @vitest/pretty-format@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/pretty-format@npm:2.1.9"
+  dependencies:
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/155f9ede5090eabed2a73361094bb35ed4ec6769ae3546d2a2af139166569aec41bb80e031c25ff2da22b71dd4ed51e5468e66a05e6aeda5f14b32e30bc18f00
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/runner@npm:2.1.9"
+  dependencies:
+    "@vitest/utils": "npm:2.1.9"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/e81f176badb12a815cbbd9bd97e19f7437a0b64e8934d680024b0f768d8670d59cad698ef0e3dada5241b6731d77a7bb3cd2c7cb29f751fd4dd35eb11c42963a
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/snapshot@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/394974b3a1fe96186a3c87f933b2f7f1f7b7cc42f9c781d80271dbb4c987809bf035fecd7398b8a3a2d54169e3ecb49655e38a0131d0e7fea5ce88960613b526
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/spy@npm:2.1.9"
+  dependencies:
+    tinyspy: "npm:^3.0.2"
+  checksum: 10c0/12a59b5095e20188b819a1d797e0a513d991b4e6a57db679927c43b362a3eff52d823b34e855a6dd9e73c9fa138dcc5ef52210841a93db5cbf047957a60ca83c
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/utils@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    loupe: "npm:^3.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/81a346cd72b47941f55411f5df4cc230e5f740d1e97e0d3f771b27f007266fc1f28d0438582f6409ea571bc0030ed37f684c64c58d1947d6298d770c21026fdf
+  languageName: node
+  linkType: hard
+
 "JSONStream@npm:^1.3.5":
   version: 1.3.5
   resolution: "JSONStream@npm:1.3.5"
@@ -893,6 +1371,13 @@ __metadata:
   bin:
     JSONStream: ./bin.js
   checksum: 10c0/0f54694da32224d57b715385d4a6b668d2117379d1f3223dc758459246cca58fdc4c628b83e8a8883334e454a0a30aa198ede77c788b55537c1844f686a751f2
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "abbrev@npm:4.0.0"
+  checksum: 10c0/b4cc16935235e80702fc90192e349e32f8ef0ed151ef506aa78c81a7c455ec18375c4125414b99f84b2e055199d66383e787675f0bcd87da7a4dbd59f9eac1d5
   languageName: node
   linkType: hard
 
@@ -927,6 +1412,13 @@ __metadata:
   version: 4.0.0-beta.5
   resolution: "aes-js@npm:4.0.0-beta.5"
   checksum: 10c0/444f4eefa1e602cbc4f2a3c644bc990f93fd982b148425fee17634da510586fc09da940dcf8ace1b2d001453c07ff042e55f7a0482b3cc9372bf1ef75479090c
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
+  version: 7.1.4
+  resolution: "agent-base@npm:7.1.4"
+  checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
   languageName: node
   linkType: hard
 
@@ -1128,6 +1620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.7":
   version: 1.0.7
   resolution: "available-typed-arrays@npm:1.0.7"
@@ -1193,6 +1692,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^20.0.1":
+  version: 20.0.3
+  resolution: "cacache@npm:20.0.3"
+  dependencies:
+    "@npmcli/fs": "npm:^5.0.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^13.0.0"
+    lru-cache: "npm:^11.1.0"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^2.0.1"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    p-map: "npm:^7.0.2"
+    ssri: "npm:^13.0.0"
+    unique-filename: "npm:^5.0.0"
+  checksum: 10c0/c7da1ca694d20e8f8aedabd21dc11518f809a7d2b59aa76a1fc655db5a9e62379e465c157ddd2afe34b19230808882288effa6911b2de26a088a6d5645123462
+  languageName: node
+  linkType: hard
+
 "call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1":
   version: 1.0.1
   resolution: "call-bind-apply-helpers@npm:1.0.1"
@@ -1254,6 +1779,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^5.1.2":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/b360fd4d38861622e5010c2f709736988b05c7f31042305fa3f4e9911f6adb80ccfb4e302068bf8ed10e835c2e2520cba0f5edc13d878b886987e5aa62483f53
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -1291,6 +1829,20 @@ __metadata:
   dependencies:
     get-func-name: "npm:^2.0.2"
   checksum: 10c0/94aa37a7315c0e8a83d0112b5bfb5a8624f7f0f81057c73e4707729cdd8077166c6aefb3d8e2b92c63ee130d4a2ff94bad46d547e12f3238cc1d78342a973841
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chownr@npm:3.0.0"
+  checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
   languageName: node
   linkType: hard
 
@@ -1530,6 +2082,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:4":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
 "debug@npm:^3.2.7":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
@@ -1557,6 +2121,13 @@ __metadata:
   dependencies:
     type-detect: "npm:^4.0.0"
   checksum: 10c0/264e0613493b43552fc908f4ff87b8b445c0e6e075656649600e1b8a17a57ee03e960156fce7177646e4d2ddaf8e5ee616d76bd79929ff593e5c79e4e5e6c517
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
   languageName: node
   linkType: hard
 
@@ -1671,6 +2242,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encoding@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "encoding@npm:0.1.13"
+  dependencies:
+    iconv-lite: "npm:^0.6.2"
+  checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
+  languageName: node
+  linkType: hard
+
 "enhanced-resolve@npm:^5.15.0":
   version: 5.18.0
   resolution: "enhanced-resolve@npm:5.18.0"
@@ -1681,7 +2261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.1":
+"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
@@ -1692,6 +2272,13 @@ __metadata:
   version: 1.1.0
   resolution: "environment@npm:1.1.0"
   checksum: 10c0/fb26434b0b581ab397039e51ff3c92b34924a98b2039dcb47e41b7bca577b9dbf134a8eadb364415c74464b682e2d3afe1a4c0eb9873dc44ea814c5d3103331d
+  languageName: node
+  linkType: hard
+
+"err-code@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "err-code@npm:2.0.3"
+  checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
   languageName: node
   linkType: hard
 
@@ -1777,6 +2364,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.5.4":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -1815,6 +2409,86 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10c0/c7e87467abb0b438639baa8139f701a06537d2b9bc758f23e8622c3b42fd0fdb5bde0f535686119e446dd9d5e4c0f238af4e14960f4771877cf818d023f6730b
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.21.3":
+  version: 0.21.5
+  resolution: "esbuild@npm:0.21.5"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.21.5"
+    "@esbuild/android-arm": "npm:0.21.5"
+    "@esbuild/android-arm64": "npm:0.21.5"
+    "@esbuild/android-x64": "npm:0.21.5"
+    "@esbuild/darwin-arm64": "npm:0.21.5"
+    "@esbuild/darwin-x64": "npm:0.21.5"
+    "@esbuild/freebsd-arm64": "npm:0.21.5"
+    "@esbuild/freebsd-x64": "npm:0.21.5"
+    "@esbuild/linux-arm": "npm:0.21.5"
+    "@esbuild/linux-arm64": "npm:0.21.5"
+    "@esbuild/linux-ia32": "npm:0.21.5"
+    "@esbuild/linux-loong64": "npm:0.21.5"
+    "@esbuild/linux-mips64el": "npm:0.21.5"
+    "@esbuild/linux-ppc64": "npm:0.21.5"
+    "@esbuild/linux-riscv64": "npm:0.21.5"
+    "@esbuild/linux-s390x": "npm:0.21.5"
+    "@esbuild/linux-x64": "npm:0.21.5"
+    "@esbuild/netbsd-x64": "npm:0.21.5"
+    "@esbuild/openbsd-x64": "npm:0.21.5"
+    "@esbuild/sunos-x64": "npm:0.21.5"
+    "@esbuild/win32-arm64": "npm:0.21.5"
+    "@esbuild/win32-ia32": "npm:0.21.5"
+    "@esbuild/win32-x64": "npm:0.21.5"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
   languageName: node
   linkType: hard
 
@@ -2082,6 +2756,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -2125,6 +2808,20 @@ __metadata:
     signal-exit: "npm:^4.1.0"
     strip-final-newline: "npm:^3.0.0"
   checksum: 10c0/2c52d8775f5bf103ce8eec9c7ab3059909ba350a5164744e9947ed14a53f51687c040a250bda833f906d1283aa8803975b84e6c8f7a7c42f99dc8ef80250d1af
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
+  languageName: node
+  linkType: hard
+
+"exponential-backoff@npm:^3.1.1":
+  version: 3.1.3
+  resolution: "exponential-backoff@npm:3.1.3"
+  checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
   languageName: node
   linkType: hard
 
@@ -2209,6 +2906,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "fdir@npm:6.5.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -2281,6 +2990,34 @@ __metadata:
   dependencies:
     is-callable: "npm:^1.1.3"
   checksum: 10c0/22330d8a2db728dbf003ec9182c2d421fbcd2969b02b4f97ec288721cda63eb28f2c08585ddccd0f77cb2930af8d958005c9e72f47141dc51816127a118f39aa
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "fs-minipass@npm:3.0.3"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10c0/63e80da2ff9b621e2cb1596abcb9207f1cf82b968b116ccd7b959e3323144cce7fb141462200971c38bbf2ecca51695069db45265705bed09a7cd93ae5b89f94
+  languageName: node
+  linkType: hard
+
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
+  conditions: os=darwin
   languageName: node
   linkType: hard
 
@@ -2419,6 +3156,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "glob@npm:13.0.0"
+  dependencies:
+    minimatch: "npm:^10.1.1"
+    minipass: "npm:^7.1.2"
+    path-scurry: "npm:^2.0.0"
+  checksum: 10c0/8e2f5821f3f7c312dd102e23a15b80c79e0837a9872784293ba2e15ec73b3f3749a49a42a31bfcb4e52c84820a474e92331c2eebf18819d20308f5c33876630a
+  languageName: node
+  linkType: hard
+
 "global-directory@npm:^4.0.1":
   version: 4.0.1
   resolution: "global-directory@npm:4.0.1"
@@ -2473,7 +3221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.4":
+"graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -2558,6 +3306,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-cache-semantics@npm:^4.1.1":
+  version: 4.2.0
+  resolution: "http-cache-semantics@npm:4.2.0"
+  checksum: 10c0/45b66a945cf13ec2d1f29432277201313babf4a01d9e52f44b31ca923434083afeca03f18417f599c9ab3d0e7b618ceb21257542338b57c54b710463b4a53e37
+  languageName: node
+  linkType: hard
+
+"http-proxy-agent@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "http-proxy-agent@npm:7.0.2"
+  dependencies:
+    agent-base: "npm:^7.1.0"
+    debug: "npm:^4.3.4"
+  checksum: 10c0/4207b06a4580fb85dd6dff521f0abf6db517489e70863dca1a0291daa7f2d3d2d6015a57bd702af068ea5cf9f1f6ff72314f5f5b4228d299c0904135d2aef921
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^7.0.1":
+  version: 7.0.6
+  resolution: "https-proxy-agent@npm:7.0.6"
+  dependencies:
+    agent-base: "npm:^7.1.2"
+    debug: "npm:4"
+  checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
 "human-signals@npm:^5.0.0":
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0"
@@ -2580,6 +3355,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3"
   checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.6.2":
+  version: 0.6.3
+  resolution: "iconv-lite@npm:0.6.3"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
   languageName: node
   linkType: hard
 
@@ -2636,6 +3420,13 @@ __metadata:
     hasown: "npm:^2.0.2"
     side-channel: "npm:^1.1.0"
   checksum: 10c0/03966f5e259b009a9bf1a78d60da920df198af4318ec004f57b8aef1dd3fe377fbc8cce63a96e8c810010302654de89f9e19de1cd8ad0061d15be28a695465c7
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:^10.0.1":
+  version: 10.1.0
+  resolution: "ip-address@npm:10.1.0"
+  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
   languageName: node
   linkType: hard
 
@@ -2948,6 +3739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "isexe@npm:3.1.1"
+  checksum: 10c0/9ec257654093443eb0a528a9c8cbba9c0ca7616ccb40abd6dde7202734d96bb86e4ac0d764f0f8cd965856aacbff2f4ce23e730dc19dfb41e3b0d865ca6fdcc7
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^2.4.1":
   version: 2.4.2
   resolution: "jiti@npm:2.4.2"
@@ -3247,10 +4045,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0, loupe@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10c0/910c872cba291309664c2d094368d31a68907b6f5913e989d301b5c25f30e97d76d77f23ab3bf3b46d0f601ff0b6af8810c10c31b91d2c6b2f132809ca2cc705
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
+  version: 11.2.4
+  resolution: "lru-cache@npm:11.2.4"
+  checksum: 10c0/4a24f9b17537619f9144d7b8e42cd5a225efdfd7076ebe7b5e7dc02b860a818455201e67fbf000765233fe7e339d3c8229fc815e9b58ee6ede511e07608c19b2
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.12":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
+  languageName: node
+  linkType: hard
+
 "make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: 10c0/171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
+  languageName: node
+  linkType: hard
+
+"make-fetch-happen@npm:^15.0.0":
+  version: 15.0.3
+  resolution: "make-fetch-happen@npm:15.0.3"
+  dependencies:
+    "@npmcli/agent": "npm:^4.0.0"
+    cacache: "npm:^20.0.1"
+    http-cache-semantics: "npm:^4.1.1"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^5.0.0"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    negotiator: "npm:^1.0.0"
+    proc-log: "npm:^6.0.0"
+    promise-retry: "npm:^2.0.1"
+    ssri: "npm:^13.0.0"
+  checksum: 10c0/525f74915660be60b616bcbd267c4a5b59481b073ba125e45c9c3a041bb1a47a2bd0ae79d028eb6f5f95bf9851a4158423f5068539c3093621abb64027e8e461
   languageName: node
   linkType: hard
 
@@ -3313,6 +4153,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "minimatch@npm:10.1.1"
+  dependencies:
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10c0/c85d44821c71973d636091fddbfbffe62370f5ee3caf0241c5b60c18cd289e916200acb2361b7e987558cd06896d153e25d505db9fc1e43e6b4b6752e2702902
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -3338,6 +4187,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass-collect@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "minipass-collect@npm:2.0.1"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10c0/5167e73f62bb74cc5019594709c77e6a742051a647fe9499abf03c71dca75515b7959d67a764bdc4f8b361cf897fbf25e2d9869ee039203ed45240f48b9aa06e
+  languageName: node
+  linkType: hard
+
+"minipass-fetch@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "minipass-fetch@npm:5.0.0"
+  dependencies:
+    encoding: "npm:^0.1.13"
+    minipass: "npm:^7.0.3"
+    minipass-sized: "npm:^1.0.3"
+    minizlib: "npm:^3.0.1"
+  dependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/9443aab5feab190972f84b64116e54e58dd87a58e62399cae0a4a7461b80568281039b7c3a38ba96453431ebc799d1e26999e548540156216729a4967cd5ef06
+  languageName: node
+  linkType: hard
+
+"minipass-flush@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "minipass-flush@npm:1.0.5"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10c0/2a51b63feb799d2bb34669205eee7c0eaf9dce01883261a5b77410c9408aa447e478efd191b4de6fc1101e796ff5892f8443ef20d9544385819093dbb32d36bd
+  languageName: node
+  linkType: hard
+
+"minipass-pipeline@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "minipass-pipeline@npm:1.2.4"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10c0/cbda57cea20b140b797505dc2cac71581a70b3247b84480c1fed5ca5ba46c25ecc25f68bfc9e6dcb1a6e9017dab5c7ada5eab73ad4f0a49d84e35093e0c643f2
+  languageName: node
+  linkType: hard
+
+"minipass-sized@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "minipass-sized@npm:1.0.3"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10c0/298f124753efdc745cfe0f2bdfdd81ba25b9f4e753ca4a2066eb17c821f25d48acea607dfc997633ee5bf7b6dfffb4eee4f2051eb168663f0b99fad2fa4829cb
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^3.0.0":
+  version: 3.3.6
+  resolution: "minipass@npm:3.3.6"
+  dependencies:
+    yallist: "npm:^4.0.0"
+  checksum: 10c0/a114746943afa1dbbca8249e706d1d38b85ed1298b530f5808ce51f8e9e941962e2a5ad2e00eae7dd21d8a4aae6586a66d4216d1a259385e9d0358f0c1eba16c
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
+  dependencies:
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -3352,6 +4277,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -3359,10 +4293,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"negotiator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "negotiator@npm:1.0.0"
+  checksum: 10c0/4c559dd52669ea48e1914f9d634227c561221dd54734070791f999c52ed0ff36e437b2e07d5c1f6e32909fc625fe46491c16e4a8f0572567d4dd15c3a4fda04b
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:latest":
+  version: 12.1.0
+  resolution: "node-gyp@npm:12.1.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    graceful-fs: "npm:^4.2.6"
+    make-fetch-happen: "npm:^15.0.0"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.5.2"
+    tinyglobby: "npm:^0.2.12"
+    which: "npm:^6.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10c0/f43efea8aaf0beb6b2f6184e533edad779b2ae38062953e21951f46221dd104006cc574154f2ad4a135467a5aae92c49e84ef289311a82e08481c5df0e8dc495
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.19":
   version: 2.0.19
   resolution: "node-releases@npm:2.0.19"
   checksum: 10c0/52a0dbd25ccf545892670d1551690fe0facb6a471e15f2cfa1b20142a5b255b3aa254af5f59d6ecb69c2bec7390bc643c43aa63b13bf5e64b6075952e716b1aa
+  languageName: node
+  linkType: hard
+
+"nopt@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "nopt@npm:9.0.0"
+  dependencies:
+    abbrev: "npm:^4.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
   languageName: node
   linkType: hard
 
@@ -3554,6 +4526,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-map@npm:^7.0.2":
+  version: 7.0.4
+  resolution: "p-map@npm:7.0.4"
+  checksum: 10c0/a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
+  languageName: node
+  linkType: hard
+
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
@@ -3617,6 +4596,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "path-scurry@npm:2.0.1"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/2a16ed0e81fbc43513e245aa5763354e25e787dab0d539581a6c3f0f967461a159ed6236b2559de23aa5b88e7dc32b469b6c47568833dd142a4b24b4f5cd2620
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -3624,10 +4613,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+  languageName: node
+  linkType: hard
+
 "pathval@npm:^1.1.1":
   version: 1.1.1
   resolution: "pathval@npm:1.1.1"
   checksum: 10c0/f63e1bc1b33593cdf094ed6ff5c49c1c0dc5dc20a646ca9725cc7fe7cd9995002d51d5685b9b2ec6814342935748b711bafa840f84c0bb04e38ff40a335c94dc
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10c0/460f4709479fbf2c45903a65655fc8f0a5f6d808f989173aeef5fdea4ff4f303dc13f7870303999add60ec49d4c14733895c0a869392e9866f1091fa64fd7581
   languageName: node
   linkType: hard
 
@@ -3642,6 +4645,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
   languageName: node
   linkType: hard
 
@@ -3668,6 +4678,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.4.43":
+  version: 8.5.6
+  resolution: "postcss@npm:8.5.6"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -3690,6 +4711,23 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
+  languageName: node
+  linkType: hard
+
+"proc-log@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "proc-log@npm:6.1.0"
+  checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+  languageName: node
+  linkType: hard
+
+"promise-retry@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "promise-retry@npm:2.0.1"
+  dependencies:
+    err-code: "npm:^2.0.2"
+    retry: "npm:^0.12.0"
+  checksum: 10c0/9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
   languageName: node
   linkType: hard
 
@@ -3851,6 +4889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"retry@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "retry@npm:0.12.0"
+  checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
+  languageName: node
+  linkType: hard
+
 "reusify@npm:^1.0.4":
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
@@ -3862,6 +4907,96 @@ __metadata:
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^4.20.0":
+  version: 4.55.1
+  resolution: "rollup@npm:4.55.1"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.55.1"
+    "@rollup/rollup-android-arm64": "npm:4.55.1"
+    "@rollup/rollup-darwin-arm64": "npm:4.55.1"
+    "@rollup/rollup-darwin-x64": "npm:4.55.1"
+    "@rollup/rollup-freebsd-arm64": "npm:4.55.1"
+    "@rollup/rollup-freebsd-x64": "npm:4.55.1"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.55.1"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.55.1"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.55.1"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.55.1"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.55.1"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.55.1"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.55.1"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.55.1"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.55.1"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.55.1"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.55.1"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.55.1"
+    "@rollup/rollup-linux-x64-musl": "npm:4.55.1"
+    "@rollup/rollup-openbsd-x64": "npm:4.55.1"
+    "@rollup/rollup-openharmony-arm64": "npm:4.55.1"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.55.1"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.55.1"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.55.1"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.55.1"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/267309f0db5c5493b2b163643dceed6e57aa20fcd75d40cf44740b8b572e747a0f9e1694b11ff518583596c37fe13ada09bf676956f50073c16cdac09e633a66
   languageName: node
   linkType: hard
 
@@ -3908,7 +5043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -3930,6 +5065,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.5":
+  version: 7.7.3
+  resolution: "semver@npm:7.7.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
   languageName: node
   linkType: hard
 
@@ -4043,6 +5187,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -4074,6 +5225,41 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     is-fullwidth-code-point: "npm:^5.0.0"
   checksum: 10c0/631c971d4abf56cf880f034d43fcc44ff883624867bf11ecbd538c47343911d734a4656d7bc02362b40b89d765652a7f935595441e519b59e2ad3f4d5d6fe7ca
+  languageName: node
+  linkType: hard
+
+"smart-buffer@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "smart-buffer@npm:4.2.0"
+  checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^8.0.3":
+  version: 8.0.5
+  resolution: "socks-proxy-agent@npm:8.0.5"
+  dependencies:
+    agent-base: "npm:^7.1.2"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.8.3"
+  checksum: 10c0/5d2c6cecba6821389aabf18728325730504bf9bb1d9e342e7987a5d13badd7a98838cc9a55b8ed3cb866ad37cc23e1086f09c4d72d93105ce9dfe76330e9d2a6
+  languageName: node
+  linkType: hard
+
+"socks@npm:^2.8.3":
+  version: 2.8.7
+  resolution: "socks@npm:2.8.7"
+  dependencies:
+    ip-address: "npm:^10.0.1"
+    smart-buffer: "npm:^4.2.0"
+  checksum: 10c0/2805a43a1c4bcf9ebf6e018268d87b32b32b06fbbc1f9282573583acc155860dc361500f89c73bfbb157caa1b4ac78059eac0ef15d1811eb0ca75e0bdadbc9d2
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 
@@ -4118,10 +5304,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssri@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "ssri@npm:13.0.0"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10c0/405f3a531cd98b013cecb355d63555dca42fd12c7bc6671738aaa9a82882ff41cdf0ef9a2b734ca4f9a760338f114c29d01d9238a65db3ccac27929bd6e6d4b2
+  languageName: node
+  linkType: hard
+
 "stable-hash@npm:^0.0.4":
   version: 0.0.4
   resolution: "stable-hash@npm:0.0.4"
   checksum: 10c0/53d010d2a1b014fb60d398c095f43912c353b7b44774e55222bb26fd428bc75b73d7bdfcae509ce927c23ca9c5aff2dc1bc82f191d30e57a879550bc2952bdb0
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
   languageName: node
   linkType: hard
 
@@ -4163,9 +5365,17 @@ __metadata:
     ts-node: "npm:>=8.0.0"
     tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:^5.4.5"
+    vitest: "npm:^2.0.0"
     yaml: "npm:^2.3.4"
   languageName: unknown
   linkType: soft
+
+"std-env@npm:^3.8.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
+  languageName: node
+  linkType: hard
 
 "string-argv@npm:~0.3.2":
   version: 0.3.2
@@ -4315,6 +5525,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar@npm:^7.5.2":
+  version: 7.5.3
+  resolution: "tar@npm:7.5.3"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/e5e3237bca325fbb33282d92d9807f4c8d81abaf71bf2627efdf93bd5610c146460c78fc7e9767d4ab5ae3c0b18af8197314c964f8cbd23b30b25bf4d42d7cb4
+  languageName: node
+  linkType: hard
+
 "text-extensions@npm:^2.0.0":
   version: 2.4.0
   resolution: "text-extensions@npm:2.4.0"
@@ -4329,10 +5552,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^0.3.0":
   version: 0.3.1
   resolution: "tinyexec@npm:0.3.1"
   checksum: 10c0/11e7a7c5d8b3bddf8b5cbe82a9290d70a6fad84d528421d5d18297f165723cb53d2e737d8f58dcce5ca56f2e4aa2d060f02510b1f8971784f97eb3e9aec28f09
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.12":
+  version: 0.2.15
+  resolution: "tinyglobby@npm:0.2.15"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.3"
+  checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tinyrainbow@npm:1.2.0"
+  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "tinyspy@npm:3.0.2"
+  checksum: 10c0/55ffad24e346622b59292e097c2ee30a63919d5acb7ceca87fc0d1c223090089890587b426e20054733f97a58f20af2c349fb7cc193697203868ab7ba00bcea0
   languageName: node
   linkType: hard
 
@@ -4581,6 +5849,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unique-filename@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unique-filename@npm:5.0.0"
+  dependencies:
+    unique-slug: "npm:^6.0.0"
+  checksum: 10c0/afb897e9cf4c2fb622ea716f7c2bb462001928fc5f437972213afdf1cc32101a230c0f1e9d96fc91ee5185eca0f2feb34127145874975f347be52eb91d6ccc2c
+  languageName: node
+  linkType: hard
+
+"unique-slug@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "unique-slug@npm:6.0.0"
+  dependencies:
+    imurmurhash: "npm:^0.1.4"
+  checksum: 10c0/da7ade4cb04eb33ad0499861f82fe95ce9c7c878b7139dc54d140ecfb6a6541c18a5c8dac16188b8b379fe62c0c1f1b710814baac910cde5f4fec06212126c6a
+  languageName: node
+  linkType: hard
+
 "update-browserslist-db@npm:^1.1.1":
   version: 1.1.2
   resolution: "update-browserslist-db@npm:1.1.2"
@@ -4618,6 +5904,114 @@ __metadata:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
   checksum: 10c0/7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
+  languageName: node
+  linkType: hard
+
+"vite-node@npm:2.1.9":
+  version: 2.1.9
+  resolution: "vite-node@npm:2.1.9"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.3.7"
+    es-module-lexer: "npm:^1.5.4"
+    pathe: "npm:^1.1.2"
+    vite: "npm:^5.0.0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/0d3589f9f4e9cff696b5b49681fdb75d1638c75053728be52b4013f70792f38cb0120a9c15e3a4b22bdd6b795ad7c2da13bcaf47242d439f0906049e73bdd756
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
+  dependencies:
+    esbuild: "npm:^0.21.3"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.4.43"
+    rollup: "npm:^4.20.0"
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^2.0.0":
+  version: 2.1.9
+  resolution: "vitest@npm:2.1.9"
+  dependencies:
+    "@vitest/expect": "npm:2.1.9"
+    "@vitest/mocker": "npm:2.1.9"
+    "@vitest/pretty-format": "npm:^2.1.9"
+    "@vitest/runner": "npm:2.1.9"
+    "@vitest/snapshot": "npm:2.1.9"
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    debug: "npm:^4.3.7"
+    expect-type: "npm:^1.1.0"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+    std-env: "npm:^3.8.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.1"
+    tinypool: "npm:^1.0.1"
+    tinyrainbow: "npm:^1.2.0"
+    vite: "npm:^5.0.0"
+    vite-node: "npm:2.1.9"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/node": ^18.0.0 || >=20.0.0
+    "@vitest/browser": 2.1.9
+    "@vitest/ui": 2.1.9
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/e339e16dccacf4589ff43cb1f38c7b4d14427956ae8ef48702af6820a9842347c2b6c77356aeddb040329759ca508a3cb2b104ddf78103ea5bc98ab8f2c3a54e
   languageName: node
   linkType: hard
 
@@ -4692,6 +6086,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "which@npm:6.0.0"
+  dependencies:
+    isexe: "npm:^3.1.1"
+  bin:
+    node-which: bin/which.js
+  checksum: 10c0/fe9d6463fe44a76232bb6e3b3181922c87510a5b250a98f1e43a69c99c079b3f42ddeca7e03d3e5f2241bf2d334f5a7657cfa868b97c109f3870625842f4cc15
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -4758,6 +6175,20 @@ __metadata:
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 10c0/4df2842c36e468590c3691c894bc9cdbac41f520566e76e24f59401ba7d8b4811eb1e34524d57e54bc6d864bcb66baab7ffd9ca42bf1eda596618f9162b91249
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "yallist@npm:4.0.0"
+  checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "yallist@npm:5.0.0"
+  checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Add optional exhaustive checking for non-enumerable OpenZeppelin AccessControl contracts by scanning `RoleGranted`/`RoleRevoked` events from contract deployment to detect unknown role holders that cannot be discovered via view functions alone.

### Features
- New `ozNonEnumerableAclOptions` config field with `exhaustive` and `eventBatchSize` options
- Event scanning from contract deployment block to current block
- Caching for contract creation blocks and event scan results (stored in `cache/` directory)
- Incremental scanning support for subsequent runs
- Detection of unexpected role holders not in configuration

### New files
- `src/cache-provider.ts` - Caching infrastructure for creation blocks and event scans
- `src/event-scanner.ts` - Event scanning and parsing logic for RoleGranted/RoleRevoked
- `src/__tests__/*.test.ts` - Unit tests (33 tests)
- `vitest.config.mts` - Vitest test configuration
- `schemas/*.json` - Updated JSON schemas with new options field

### Usage

```yaml
ozNonEnumerableAcl:
  *DEFAULT_ADMIN_ROLE: [*agent]
  *DEPOSITS_ENABLER_ROLE: [*agent]
ozNonEnumerableAclOptions:
  exhaustive: true          # Enable event scanning
  eventBatchSize: 3000      # Optional, default 5000
```

### How it works

1. Fetches contract creation block from Etherscan API (cached)
2. Scans all `RoleGranted`/`RoleRevoked` events from deployment to current block
3. Builds a complete map of current role holders from event history
4. Compares against config - flags any unexpected holders as errors
5. Falls back to non-exhaustive check if explorer info unavailable

## Test plan

- [x] `yarn build` - TypeScript compiles without errors
- [x] `yarn test:unit` - All 33 unit tests pass
- [x] `yarn lint` - No linting errors
- [x] `yarn format` - Code properly formatted
- [x] JSON schemas generated with new fields
- [ ] Manual test with exhaustive mode on real config

🤖 Generated with [Claude Code](https://claude.com/claude-code)