### PR TITLE
chore: drop CI devcontainer usage, simplify devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,3 @@
-ARG DEVCONTAINER_BASE_IMAGE=mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
-FROM ${DEVCONTAINER_BASE_IMAGE}
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
 
-ARG YARN_VERSION=4.3.1
-
-RUN corepack enable \
-    && corepack prepare "yarn@${YARN_VERSION}" --activate \
-    && yarn --version
+RUN corepack enable && corepack prepare yarn@4.3.1 --activate

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,38 +2,12 @@
   "name": "state-mate",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": "..",
-    "args": {
-      "DEVCONTAINER_BASE_IMAGE": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
-      "YARN_VERSION": "4.3.1"
-    }
+    "context": ".."
   },
   "workspaceFolder": "/workspaces/state-mate",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
-      "settings": {
-        "editor.formatOnSave": true,
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.codeActionsOnSave": {
-          "source.fixAll.eslint": "always"
-        },
-        "files.trimTrailingWhitespace": true,
-        "cSpell.words": [
-          "apikey",
-          "bscscan",
-          "Depositable",
-          "esbenp",
-          "IERC165",
-          "minato",
-          "Mutables",
-          "Ossifiable",
-          "REBASABLE",
-          "REPLACEME",
-          "SONEIUM",
-          "typebox"
-        ]
-      },
       "extensions": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "redhat.vscode-yaml"]
     }
   }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cp -n .env.sample .env 2>/dev/null || true
+[ -f .env ] || cp .env.sample .env
 yarn install --immutable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,9 +1,13 @@
 name: Setup state-mate
-description: Enable Corepack, install Node 20 with yarn cache, and run yarn install --immutable.
+description: Enable Corepack, install Node 20 (yarn cache), run yarn install --immutable.
 
 runs:
   using: composite
   steps:
+    # Corepack must come before actions/setup-node: when `cache: yarn` is
+    # set, setup-node invokes yarn to locate the cache folder. Without the
+    # shim, it falls back to the runner's system yarn (v1), which refuses
+    # to run a project with `packageManager: yarn@4.3.1` in package.json.
     - name: Enable Corepack
       run: corepack enable
       shell: bash
@@ -15,5 +19,7 @@ runs:
         cache: "yarn"
 
     - name: Install dependencies
+      env:
+        HUSKY: "0"
       run: yarn install --immutable
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "20"
         cache: "yarn"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup state-mate
+description: Enable Corepack, install Node 20 with yarn cache, and run yarn install --immutable.
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      run: corepack enable
+      shell: bash
+
+    - name: Setup Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: "20"
+        cache: "yarn"
+
+    - name: Install dependencies
+      run: yarn install --immutable
+      shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "eslint-*"
+      prettier:
+        patterns:
+          - "prettier"
+          - "prettier-*"
+          - "eslint-config-prettier"
+          - "eslint-plugin-prettier"
+      typescript:
+        patterns:
+          - "typescript"
+          - "ts-node"
+          - "tsconfig-paths"
+          - "@tsconfig/*"
+      types:
+        patterns:
+          - "@types/*"
+      commitlint:
+        patterns:
+          - "@commitlint/*"
+          - "husky"
+          - "lint-staged"
+    labels: ["dependencies", "npm"]
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,26 +22,6 @@ updates:
           - "@eslint/*"
           - "@typescript-eslint/*"
           - "eslint-*"
-      prettier:
-        patterns:
-          - "prettier"
-          - "prettier-*"
-          - "eslint-config-prettier"
-          - "eslint-plugin-prettier"
-      typescript:
-        patterns:
-          - "typescript"
-          - "ts-node"
-          - "tsconfig-paths"
-          - "@tsconfig/*"
-      types:
-        patterns:
-          - "@types/*"
-      commitlint:
-        patterns:
-          - "@commitlint/*"
-          - "husky"
-          - "lint-staged"
     labels: ["dependencies", "npm"]
     commit-message:
       prefix: "chore(deps)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,43 +53,18 @@ jobs:
       L1_MAINNET_RPC_URL: ${{ secrets.MAINNET_REMOTE_RPC_URL }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup
 
       - name: Run state-mate
-        run: |
-          yarn start ${{ matrix.config }}
+        run: yarn start ${{ matrix.config }}
 
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup
 
       - name: Run linter
         run: yarn lint
@@ -101,20 +76,8 @@ jobs:
     name: Validate Schemas
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup
 
       - name: Generate schemas
         run: yarn schemas

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  DEVCONTAINER_BUILD_CACHE_DIR: .buildx-cache
-  DEVCONTAINER_IMAGE: state-mate:${{ github.sha }}
-
 jobs:
   test:
     name: Test ${{ matrix.config }}
@@ -60,55 +56,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Restore devcontainer build cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.DEVCONTAINER_BUILD_CACHE_DIR }}
-          key: devcontainer-buildx-${{ runner.os }}-${{ hashFiles('.devcontainer/Dockerfile', '.dockerignore') }}
-          restore-keys: |
-            devcontainer-buildx-${{ runner.os }}-
+      - name: Enable Corepack
+        run: corepack enable
 
-      - name: Build devcontainer image
-        run: |
-          mkdir -p "${DEVCONTAINER_BUILD_CACHE_DIR}"
-          docker buildx create --use --name state-mate-builder
-          docker buildx inspect --bootstrap
-          docker buildx build \
-            --cache-from "type=local,src=${DEVCONTAINER_BUILD_CACHE_DIR}" \
-            --cache-to "type=local,dest=${DEVCONTAINER_BUILD_CACHE_DIR}-new,mode=max" \
-            --file .devcontainer/Dockerfile \
-            --load \
-            --tag "${DEVCONTAINER_IMAGE}" \
-            .
-          rm -rf "${DEVCONTAINER_BUILD_CACHE_DIR}"
-          mv "${DEVCONTAINER_BUILD_CACHE_DIR}-new" "${DEVCONTAINER_BUILD_CACHE_DIR}"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --immutable
 
       - name: Run state-mate
-        env:
-          STATE_MATE_CONFIG: ${{ matrix.config }}
         run: |
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            --volume "${GITHUB_WORKSPACE}:/workspaces/state-mate" \
-            --workdir /workspaces/state-mate \
-            --env CI=true \
-            --env HUSKY=0 \
-            --env HOME=/tmp/state-mate-home \
-            --env XDG_CACHE_HOME=/tmp/state-mate-home/.cache \
-            --env COREPACK_HOME=/tmp/state-mate-home/.cache/corepack \
-            --env YARN_CACHE_FOLDER=/tmp/state-mate-home/.cache/yarn \
-            --env ETHERSCAN_TOKEN \
-            --env MAINNET_REMOTE_RPC_URL \
-            --env HOODI_REMOTE_RPC_URL \
-            --env L1_MAINNET_RPC_URL \
-            --env STATE_MATE_CONFIG \
-            "${DEVCONTAINER_IMAGE}" \
-            bash -lc '
-              set -euo pipefail
-              mkdir -p "$HOME" "$XDG_CACHE_HOME" "$COREPACK_HOME" "$YARN_CACHE_FOLDER"
-              yarn install --immutable
-              yarn start "$STATE_MATE_CONFIG"
-            '
+          yarn start ${{ matrix.config }}
 
   lint:
     name: Lint and Format Check
@@ -117,49 +79,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Restore devcontainer build cache
-        uses: actions/cache@v4
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          path: ${{ env.DEVCONTAINER_BUILD_CACHE_DIR }}
-          key: devcontainer-buildx-${{ runner.os }}-${{ hashFiles('.devcontainer/Dockerfile', '.dockerignore') }}
-          restore-keys: |
-            devcontainer-buildx-${{ runner.os }}-
+          node-version: "20"
+          cache: "yarn"
 
-      - name: Build devcontainer image
-        run: |
-          mkdir -p "${DEVCONTAINER_BUILD_CACHE_DIR}"
-          docker buildx create --use --name state-mate-builder
-          docker buildx inspect --bootstrap
-          docker buildx build \
-            --cache-from "type=local,src=${DEVCONTAINER_BUILD_CACHE_DIR}" \
-            --cache-to "type=local,dest=${DEVCONTAINER_BUILD_CACHE_DIR}-new,mode=max" \
-            --file .devcontainer/Dockerfile \
-            --load \
-            --tag "${DEVCONTAINER_IMAGE}" \
-            .
-          rm -rf "${DEVCONTAINER_BUILD_CACHE_DIR}"
-          mv "${DEVCONTAINER_BUILD_CACHE_DIR}-new" "${DEVCONTAINER_BUILD_CACHE_DIR}"
+      - name: Install dependencies
+        run: yarn install --immutable
 
-      - name: Run lint and format checks
-        run: |
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            --volume "${GITHUB_WORKSPACE}:/workspaces/state-mate" \
-            --workdir /workspaces/state-mate \
-            --env CI=true \
-            --env HUSKY=0 \
-            --env HOME=/tmp/state-mate-home \
-            --env XDG_CACHE_HOME=/tmp/state-mate-home/.cache \
-            --env COREPACK_HOME=/tmp/state-mate-home/.cache/corepack \
-            --env YARN_CACHE_FOLDER=/tmp/state-mate-home/.cache/yarn \
-            "${DEVCONTAINER_IMAGE}" \
-            bash -lc '
-              set -euo pipefail
-              mkdir -p "$HOME" "$XDG_CACHE_HOME" "$COREPACK_HOME" "$YARN_CACHE_FOLDER"
-              yarn install --immutable
-              yarn lint
-              yarn format
-            '
+      - name: Run linter
+        run: yarn lint
+
+      - name: Check formatting
+        run: yarn format
 
   schemas:
     name: Validate Schemas
@@ -168,49 +104,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Restore devcontainer build cache
-        uses: actions/cache@v4
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          path: ${{ env.DEVCONTAINER_BUILD_CACHE_DIR }}
-          key: devcontainer-buildx-${{ runner.os }}-${{ hashFiles('.devcontainer/Dockerfile', '.dockerignore') }}
-          restore-keys: |
-            devcontainer-buildx-${{ runner.os }}-
+          node-version: "20"
+          cache: "yarn"
 
-      - name: Build devcontainer image
-        run: |
-          mkdir -p "${DEVCONTAINER_BUILD_CACHE_DIR}"
-          docker buildx create --use --name state-mate-builder
-          docker buildx inspect --bootstrap
-          docker buildx build \
-            --cache-from "type=local,src=${DEVCONTAINER_BUILD_CACHE_DIR}" \
-            --cache-to "type=local,dest=${DEVCONTAINER_BUILD_CACHE_DIR}-new,mode=max" \
-            --file .devcontainer/Dockerfile \
-            --load \
-            --tag "${DEVCONTAINER_IMAGE}" \
-            .
-          rm -rf "${DEVCONTAINER_BUILD_CACHE_DIR}"
-          mv "${DEVCONTAINER_BUILD_CACHE_DIR}-new" "${DEVCONTAINER_BUILD_CACHE_DIR}"
+      - name: Install dependencies
+        run: yarn install --immutable
 
-      - name: Validate schemas
+      - name: Generate schemas
+        run: yarn schemas
+
+      - name: Check if schemas are up to date
         run: |
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            --volume "${GITHUB_WORKSPACE}:/workspaces/state-mate" \
-            --workdir /workspaces/state-mate \
-            --env CI=true \
-            --env HUSKY=0 \
-            --env HOME=/tmp/state-mate-home \
-            --env XDG_CACHE_HOME=/tmp/state-mate-home/.cache \
-            --env COREPACK_HOME=/tmp/state-mate-home/.cache/corepack \
-            --env YARN_CACHE_FOLDER=/tmp/state-mate-home/.cache/yarn \
-            "${DEVCONTAINER_IMAGE}" \
-            bash -lc '
-              set -euo pipefail
-              mkdir -p "$HOME" "$XDG_CACHE_HOME" "$COREPACK_HOME" "$YARN_CACHE_FOLDER"
-              yarn install --immutable
-              yarn schemas
-              if ! git diff --exit-code schemas/; then
-                echo "Error: Schema files are not up to date. Please run '\''yarn schemas'\'' and commit the changes."
-                exit 1
-              fi
-            '
+          if ! git diff --exit-code schemas/; then
+            echo "Error: Schema files are not up to date. Please run 'yarn schemas' and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       L1_MAINNET_RPC_URL: ${{ secrets.MAINNET_REMOTE_RPC_URL }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
 
       - name: Run state-mate
@@ -63,7 +63,7 @@ jobs:
     name: Lint and Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
 
       - name: Run linter
@@ -76,7 +76,7 @@ jobs:
     name: Validate Schemas
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
 
       - name: Generate schemas


### PR DESCRIPTION
Follow-up to #69. Keeps the `.devcontainer/` for local dev; reverts the CI integration and trims duplicated config.

