### PR TITLE
fix: reject shadowed generic ABI lookups

### DIFF
--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -146,6 +146,20 @@ function formatConsolidatedKeys(keys: string[]): string {
   return `${preview}, ... (+${keys.length - CONSOLIDATED_KEYS_PREVIEW_LIMIT} more)`;
 }
 
+function formatGenericAbiConflictMessage(
+  key: string,
+  contractName: string,
+  address: string,
+  addressMatches: string[],
+): string {
+  return (
+    `ABI lookup for ${chalk.yellow(key)} would use generic ABI ${chalk.yellow(contractName)}, ` +
+    `but address-specific ABI key(s) exist for ${chalk.yellow(address)}:\n` +
+    `${addressMatches.join(", ")}\n\n` +
+    `Use the address-specific contract name in YAML so coverage is checked against the real contract ABI.`
+  );
+}
+
 type LoadAbiOptions = {
   allowAddressFallback?: boolean;
   failSilently?: boolean;
@@ -172,7 +186,16 @@ export function loadAbiFromFile(
     // Try with address first, then without
     let abi = abis[key];
     if (!abi && address) {
-      abi = abis[contractName];
+      const genericAbi = abis[contractName];
+      if (genericAbi) {
+        const addressMatches = findAbiKeysByAddress(allKeys, address);
+        if (addressMatches.length > 0) {
+          const message = formatGenericAbiConflictMessage(key, contractName, address, addressMatches);
+          if (failSilently) return null;
+          logErrorAndExit(message);
+        }
+        abi = genericAbi;
+      }
     }
     if (!abi && address && allowAddressFallback) {
       const addressMatches = findAbiKeysByAddress(allKeys, address);
@@ -204,6 +227,17 @@ export function loadAbiFromFile(
     let abiPath;
     try {
       abiPath = _findAbiPath(contractName, address, { shouldThrow: true, allowAddressFallback });
+      const addressMatches = findAddressSpecificAbiFiles(address);
+      if (isGenericAbiPath(contractName, abiPath) && addressMatches.length > 0) {
+        const message = formatGenericAbiConflictMessage(
+          getAbiKey(contractName, address),
+          contractName,
+          address,
+          addressMatches,
+        );
+        if (failSilently) return null;
+        logErrorAndExit(message);
+      }
     } catch (error) {
       const message =
         `Error finding ABI file for contract
@@ -491,6 +525,27 @@ function toLowerCaseAddress(fileName: string): string {
 
   const address = match[0];
   return fileName.replace(address, address.toLowerCase());
+}
+
+function findAddressSpecificAbiFiles(address: string): string[] {
+  if (!fs.existsSync(g_Arguments.abiDirPath)) return [];
+
+  try {
+    return findAbiKeysByAddress(fs.readdirSync(g_Arguments.abiDirPath), address).filter((fileName) =>
+      fileName.endsWith(".json"),
+    );
+  } catch (error) {
+    logErrorAndExit(`Failed to read ${chalk.yellow(g_Arguments.abiDirPath)}:\n ${printError(error)}`);
+  }
+}
+
+function isGenericAbiPath(contractName: string, abiPath: string): boolean {
+  const relativeAbiPath = path.relative(g_Arguments.abiDirPath, abiPath);
+
+  return (
+    relativeAbiPath === `${contractName}.json` ||
+    relativeAbiPath === path.join(`${contractName}.sol`, `${contractName}.json`)
+  );
 }
 
 function normalizeConsolidatedAbiKeys(


### PR DESCRIPTION
## What changed

- Reject ABI resolution when a generic ABI key would shadow address-specific ABI keys for the same contract address.
- Apply the guard to both consolidated and individual ABI modes.  

## Why

Minimal state ABIs such as `WithdrawalVaultState` can otherwise make coverage checks pass against only the trimmed ABI, even when full address-specific ABIs exist for the same address.

##
  Validation

- `yarn lint`
- `HOODI_REMOTE_RPC_URL=https://hoodi.drpc.org yarn start configs/srv3-cmv2/hoodi/after_voting.yaml -o l1/withdrawalVault` fails with the new generic/address-specific ABI conflict
  message.

Note: `yarn build` currently fails before this change on TypeScript 6 `baseUrl` deprecation in `tsconfig.json`; left untouched.