### PR TITLE
fix(mellow_strategy): update stale verifier merkle roots

### DIFF
--- a/configs/mellow_strategy/mellow-strategy.yaml
+++ b/configs/mellow_strategy/mellow-strategy.yaml
@@ -2020,7 +2020,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0xa676bdddff6894164a43f900342e8a4d2b89872d1c93a339ea5a58fae2388779"
+        merkleRoot: "0x0defb6ee7a9988e2247999be4b92bbcfff0ef4bcaf98a4e1f7e665e805c129a5"
         vault: *vault
         verifyCall:
       implementationChecks:
@@ -2068,7 +2068,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0xc87be1d795d3fd7b33cacefa6bc5a0b71f5b4ffe7764f8f02c7137e37e6c1c48"
+        merkleRoot: "0x72f7eb192cdbb602a41a2fa676fc5a7885f92bfcafdb7b9c8ed2b84cb83861ca"
         vault: *vault
         verifyCall:
       implementationChecks:
@@ -2116,7 +2116,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0x024f7e69ecf4c1d49c751885deab80b955cad770ae9c9cfd9bef09917d3b65f7"
+        merkleRoot: "0x539f54782bab568bc60271227f4807a394bda17fd8622e78c2b34dc342fe0ade"
         vault: *vault
         verifyCall:
       implementationChecks:
@@ -2260,7 +2260,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0x0170f52cc06f6d9b9ecc008db9387f06c19efbe3abcb4afc9d08e50d3c86ea4f"
+        merkleRoot: "0xbbf7c96b84484997f65758984d04874d1e7f814487536ca566bba51313c2dfac"
         vault: *vault
         verifyCall:
       implementationChecks:


### PR DESCRIPTION
## Summary

The `mellow-strategy.yaml` CI check fails on four verifier `merkleRoot` mismatches — the on-chain roots were updated (curator permissions) and the config drifted. This aligns the config with current on-chain values (verified against mainnet).

| verifier | address | new merkleRoot (on-chain) |
|---|---|---|
| verifier2 | `0x1616d39a201D246cbD1B3B145234638f7719b53A` | `0x0defb6ee7a9988e2247999be4b92bbcfff0ef4bcaf98a4e1f7e665e805c129a5` |
| verifier3 | `0xd662dF7C0FAF0Fe6446638651b05C287806AD1AE` | `0x72f7eb192cdbb602a41a2fa676fc5a7885f92bfcafdb7b9c8ed2b84cb83861ca` |
| verifier4 | `0x58C4B6B0d6CFf1d684E4B8Ee899550F4B68A1031` | `0x539f54782bab568bc60271227f4807a394bda17fd8622e78c2b34dc342fe0ade` |
| verifier7 | `0xDF96d59d3688C56ca29aED045FE67C84bbc38461` | `0xbbf7c96b84484997f65758984d04874d1e7f814487536ca566bba51313c2dfac` |

All four verifier checks pass against chain after the update.
