### PR TITLE
ci: add dependabot cooldown and esm-major ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns: ["*"]
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       eslint:
         patterns:
@@ -22,6 +26,13 @@ updates:
           - "@eslint/*"
           - "@typescript-eslint/*"
           - "eslint-*"
+    ignore:
+      # ESM-only since the next major, the project is CommonJS;
+      # chalk and chai (section-validators/base.ts) are runtime imports
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "chai"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "npm"]
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
- 7-day cooldown for both ecosystems, matching the org-wide configs (`core` et al.)
- ignore chalk and chai majors: both are ESM-only since their next major, while the project is CommonJS — chalk is a runtime dependency and chai is imported in the CLI core (`src/section-validators/base.ts`). Closes the recurring #98 / #95 class of PRs; 4.x minors and patches keep flowing.