### PR TITLE
docs: rewrite README setup, make ABI fetch default on --generate

### DIFF
--- a/.claude/skills/state-mate/skill.md
+++ b/.claude/skills/state-mate/skill.md
@@ -1,6 +1,6 @@
 ---
 name: state-mate
-description: Configure and verify state-mate YAML for EVM smart-contract state checks — contracts, proxies (Transparent, Ossifiable, AppProxyUpgradeable), Safe multisigs, ozAcl and ozNonEnumerableAcl access control, ABI resolution and updates, EIP-1967 storage slots, seed configs and --generate, REPLACEME discovery, and common error triage.
+description: Configure and verify state-mate YAML for EVM smart-contract state checks: contracts, proxies (Transparent, Ossifiable, AppProxyUpgradeable), Safe multisigs, ozAcl and ozNonEnumerableAcl access control, ABI resolution and updates, EIP-1967 storage slots, seed configs and --generate, REPLACEME discovery, and common error triage.
 ---
 
 # State-Mate Skill
@@ -23,7 +23,7 @@ Validate EVM smart-contract state against YAML configs. state-mate calls view fu
 ## Top-level structure
 
 ```yaml
-parameters: # optional — arbitrary constants used across the file
+parameters: # optional, arbitrary constants used across the file
   - &someConstant "0x..."
 
 deployed: # address book, grouped by chain
@@ -46,7 +46,7 @@ roles: # bytes32 role hashes, often many (one per domain)
 eoa: # named EOAs (deployer, signer addresses); useful for "deployer renounced" checks
   - &deployer "0x..."
 
-l1: # per-chain section — key matches deployed.* key
+l1: # per-chain section, key matches deployed.* key
   rpcUrl: L1_MAINNET_RPC_URL # env-var name, or inline URL
   explorerHostname: api.etherscan.io/v2/api
   explorerTokenEnv: ETHERSCAN_TOKEN
@@ -60,7 +60,7 @@ l2: # present when deployed.l2 exists
   # ...
 ```
 
-`parameters`, `deployed`, `misc`, `roles`, `eoa` are anchor-only sections — they define YAML anchors (`&name`) that later sections reference via `*name`. Only `<chain-key>` sections with `contracts:` produce on-chain calls.
+`parameters`, `deployed`, `misc`, `roles`, `eoa` are anchor-only sections that define YAML anchors (`&name`) for later sections to reference via `*name`. Only `<chain-key>` sections with `contracts:` produce on-chain calls.
 
 ## Contract patterns
 
@@ -97,7 +97,7 @@ contractName:
     # against the proxy (implementation logic, proxy state)
     someFunction: expectedValue
   implementationChecks:
-    # against the impl directly (uninitialized state — zeros/empties)
+    # against the impl directly (uninitialized state, zeros/empties)
     someFunction: *ZERO_ADDRESS
 ```
 
@@ -170,7 +170,7 @@ multisigName:
         result: true
 ```
 
-Transient values (Safe `nonce`, queue `canBeRemoved`, `getResumeSinceTimestamp` after a transient pause) drift over time — either leave the key `null` to skip, or accept that each state change needs a config update.
+Transient values (Safe `nonce`, queue `canBeRemoved`, `getResumeSinceTimestamp` after a transient pause) drift over time. Either leave the key `null` to skip, or accept that each state change needs a config update.
 
 ### Contract with indexed collections
 
@@ -241,7 +241,7 @@ checks:
 
 ### Tuple / array returns
 
-Document field names with comments — tuple positions aren't obvious from YAML alone:
+Document field names with comments. Tuple positions aren't obvious from YAML alone:
 
 ```yaml
 checks:
@@ -319,13 +319,13 @@ checks:
   unknownValue: "REPLACEME"
 ```
 
-Run `yarn start config.yml` — the error surfaces the actual on-chain value:
+Run `yarn start config.yml`. The error surfaces the actual on-chain value:
 
 ```
 ✗ .unknownValue: expected REPLACEME, got 0xb13b0c93...
 ```
 
-**Do not** use `REPLACEME` in `deployed:` — invalid-address errors block the whole file from loading. For unknown addresses, read EIP-1967 slots first:
+**Do not** use `REPLACEME` in `deployed:`. Invalid-address errors block the whole file from loading. For unknown addresses, read EIP-1967 slots first:
 
 ```bash
 cast admin $PROXY --rpc-url $RPC           # EIP-1967 admin
@@ -346,9 +346,9 @@ cast call $CONTRACT "hasRole(bytes32,address)(bool)" $ROLE $ADDRESS --rpc-url $R
 
 ## Seed configs
 
-A seed config is a thin starter file named `*.seed.yml`. It contains only address-book and chain-explorer sections (`deployed:`, `l1:` / `l2:` with `rpcUrl` / `explorerHostname`, optional `eoa:` / `roles:` / `misc:`) — **no `contracts:` block**. `yarn start <seed> --generate` walks every anchor under `deployed:`, resolves the ABI for each address, and writes a sibling `*.seed.generated.yml` with a populated `contracts:` block where each function value is `REPLACEME` (and, for proxies, a commented-out `implementationChecks` stub).
+A seed config is a thin starter file named `*.seed.yml`. It contains only address-book and chain-explorer sections (`deployed:`, `l1:` / `l2:` with `rpcUrl` / `explorerHostname`, optional `eoa:` / `roles:` / `misc:`), with **no `contracts:` block**. `yarn start <seed> --generate` walks every anchor under `deployed:`, resolves the ABI for each address, and writes a sibling `*.seed.generated.yml` with a populated `contracts:` block where each function value is `REPLACEME` (and, for proxies, a commented-out `implementationChecks` stub).
 
-`--generate` on its own does not fetch ABIs — it only uses ABIs already on disk. Combine with `--update-abi-missing` on first run.
+`--generate` on its own does not fetch ABIs. It uses only ABIs already on disk. Combine with `--update-abi-missing` on first run.
 
 ```bash
 yarn start configs/proto/mainnet.seed.yml --generate --update-abi-missing
@@ -360,16 +360,16 @@ yarn start configs/proto/mainnet.seed.generated.yml
 
 Adding a new contract to an existing config:
 
-1. **Resolve addresses** — `cast admin` / `cast implementation` for proxies; EIP-1967 slots for anything non-standard.
+1. **Resolve addresses:** `cast admin` / `cast implementation` for proxies; EIP-1967 slots for anything non-standard.
 2. **Define anchors** in `deployed:` (and `implementation:` addresses in the same section with a matching name).
-3. **Write the contract stanza** — pick the proxy pattern, seed `checks:` with function names, leave unknowns as `REPLACEME`.
-4. **Download ABIs** — `yarn start config.yml --update-abi-missing`. Resolution depends on mode: consolidated (`abis.json.gz`) tries the `Name-{address}` key first, then `Name`; individual-file mode (`abi/*.json`) tries `Name.json`, then `Name.sol/Name.json`, then `Name-{address}.json`.
-5. **Run, read actuals, replace** — iterate `yarn start config.yml -o l1/contractName` until green.
-6. **Access control** — probe with `cast call getRoleMemberCount`; choose `ozAcl` / `ozNonEnumerableAcl` / `hasRole`. List every role constant, including empty ones (`[]`).
+3. **Write the contract stanza:** pick the proxy pattern, seed `checks:` with function names, leave unknowns as `REPLACEME`.
+4. **Download ABIs:** `yarn start config.yml --update-abi-missing`. Resolution depends on mode: consolidated (`abis.json.gz`) tries the `Name-{address}` key first, then `Name`; individual-file mode (`abi/*.json`) tries `Name.json`, then `Name.sol/Name.json`, then `Name-{address}.json`.
+5. **Run, read actuals, replace:** iterate `yarn start config.yml -o l1/contractName` until green.
+6. **Access control:** probe with `cast call getRoleMemberCount`; choose `ozAcl` / `ozNonEnumerableAcl` / `hasRole`. List every role constant, including empty ones (`[]`).
 
 ## Implementation checks
 
-For `implementationChecks`, use uninitialized defaults — implementations store no state:
+For `implementationChecks`, use uninitialized defaults. Implementations store no state:
 
 | Type    | Default                                        |
 | ------- | ---------------------------------------------- |
@@ -394,12 +394,12 @@ yarn start config.seed.yml --generate                     # expand seed → *.se
 
 ## Best practices
 
-- **Named anchors for addresses** — define every address in `deployed:` / `eoa:`; don't hardcode `0x…` inside `checks:` values. Inline hex is fine for **data** (bytes32 constants, selectors).
-- **Deployer renounced** — confirm `deployer` is not a role holder (not in any `ozAcl` list; `hasRole(…, deployer) = false`).
-- **Empty roles are explicit** — list unused roles with `[]` so a future grant is caught.
-- **Comment tuples** — field names aren't derivable from YAML; look up the ABI.
-- **Rate-limited RPC?** — scope with `-o l1/contractName` to reduce concurrency.
-- **Transient values** — Safe `nonce`, `getResumeSinceTimestamp`, queue operational flags etc. belong as `null` unless you intentionally want the check to fire on every state change.
+- **Named anchors for addresses:** define every address in `deployed:` / `eoa:`; don't hardcode `0x…` inside `checks:` values. Inline hex is fine for **data** (bytes32 constants, selectors).
+- **Deployer renounced:** confirm `deployer` is not a role holder (not in any `ozAcl` list; `hasRole(…, deployer) = false`).
+- **Empty roles are explicit:** list unused roles with `[]` so a future grant is caught.
+- **Comment tuples:** field names aren't derivable from YAML; look up the ABI.
+- **Rate-limited RPC?** Scope with `-o l1/contractName` to reduce concurrency.
+- **Transient values:** Safe `nonce`, `getResumeSinceTimestamp`, queue operational flags etc. belong as `null` unless you want the check to fire on every state change.
 
 ## Troubleshooting
 
@@ -411,8 +411,8 @@ yarn start config.seed.yml --generate                     # expand seed → *.se
 
 ### `getRoleMemberCount` reverted / `no matching function`
 
-- The contract is standard AccessControl, not Enumerable — switch to `ozNonEnumerableAcl:` or raw `hasRole` checks.
-- Or the contract doesn't expose role management at all — skip the role block.
+- The contract is standard AccessControl, not Enumerable. Switch to `ozNonEnumerableAcl:` or raw `hasRole` checks.
+- Or the contract doesn't expose role management at all. Skip the role block.
 
 ### `missing revert data` with `data=null`
 
@@ -422,7 +422,7 @@ yarn start config.seed.yml --generate                     # expand seed → *.se
 
 ### `Invalid address` in `deployed:`
 
-- `REPLACEME` is invalid in `deployed:` — resolve the address via `cast storage` / `cast admin` first, then add a real anchor.
+- `REPLACEME` is invalid in `deployed:`. Resolve the address via `cast storage` / `cast admin` first, then add a real anchor.
 
 ### Ambiguous function overload
 
@@ -434,4 +434,4 @@ cast call $CONTRACT "itemAt(bool,uint256)(address)" true 0 --rpc-url $RPC
 
 ### Unexpected tuple length / field order
 
-The YAML array must match the on-chain struct's field order exactly. Look up the canonical layout in the contract's Solidity source or the ABI's `components` field — don't rely on field names in the contract UI.
+The YAML array must match the on-chain struct's field order exactly. Look up the canonical layout in the contract's Solidity source or the ABI's `components` field. Don't rely on field names in the contract UI.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,23 @@ corepack enable
 yarn install
 ```
 
-3. Specify RPC endpoints for your target networks, e.g.
+3. Configure RPC endpoints and explorer tokens
+
+Copy the sample env file and fill in the values:
 
 ```sh
-# config.seed.yaml
-
-export L1_MAINNET_RPC_URL=%YOUR_RPC_URL%
-export L2_MAINNET_RPC_URL=%YOUR_RPC_URL%
+cp .env.sample .env
 ```
+
+```sh
+# .env
+
+L1_MAINNET_RPC_URL=%YOUR_RPC_URL%
+L2_MAINNET_RPC_URL=%YOUR_RPC_URL%
+ETHERSCAN_TOKEN=%YOUR_TOKEN%
+```
+
+Configs reference these by their **env-var name** (e.g. `rpcUrl: L1_MAINNET_RPC_URL`). `.env` is gitignored.
 
 4. Prepare a seed config
 
@@ -70,6 +79,7 @@ l1:
   rpcUrl: L1_MAINNET_RPC_URL
   explorerHostname: api.etherscan.io
   explorerTokenEnv: ETHERSCAN_TOKEN
+  chainId: 1 # required for etherscan.io explorers (v2 API)
 
 l2:
   rpcUrl: L2_MAINNET_RPC_URL
@@ -77,13 +87,15 @@ l2:
   # explorerTokenEnv: ETHERSCAN_MODE_TOKEN
 ```
 
-4. Start the program to generate a populated config from the seed one
+5. Start the program to generate a populated config from the seed one
 
 ```sh
 yarn start path/to/config.seed.yaml --generate
 ```
 
-5. Edit the generated config manually
+`--generate` downloads missing ABIs and skips ones already present. Add `--update-abi` to re-download and overwrite existing ABIs.
+
+6. Edit the generated config manually
 
 ### Configuration
 
@@ -111,6 +123,9 @@ roles:
 
 l1:
   rpcUrl: L1_MAINNET_RPC_URL # env variable
+  explorerHostname: api.etherscan.io
+  explorerTokenEnv: ETHERSCAN_TOKEN
+  chainId: 1 # required for etherscan.io explorers (v2 API)
   contracts:
     myContract:
       name: "myContract"
@@ -128,7 +143,7 @@ l1:
 
 ### ABIs
 
-All required ABIs are located in the same directory as the config and placed under `abi` folder being downloaded upon the first launch. See [configs](/configs/).
+ABIs live in an `abi/` folder next to the config, or in a consolidated file (see below). `--generate` fetches missing ABIs for you. A plain check run does not; pass `--update-abi-missing` (or `--update-abi`) to fetch them. See [configs](/configs/).
 
 state-mate supports two ABI storage formats:
 
@@ -140,16 +155,21 @@ state-mate supports two ABI storage formats:
 For large projects with many contracts, you can consolidate all individual ABI files into a single compressed file to reduce repository size and improve performance:
 
 ```sh
-yarn consolidate-abi path/to/config/abi --compress
+yarn consolidate-abi path/to/config/abi
 ```
 
 This command:
 
 - Reads all `.json` files from the specified ABI directory
 - Validates each ABI format
-- Consolidates them into a single `abis.json.gz` file (or `abis.json` without `--compress`)
-- Places the output file alongside your config file
+- Consolidates them into a single compressed `abis.json.gz` file alongside your config
 - Provides compression statistics
+
+Compression is the default. For an uncompressed `abis.json`, pass `--no-compress`:
+
+```sh
+yarn consolidate-abi path/to/config/abi --no-compress
+```
 
 **Note**: You cannot use both consolidated and individual ABI files simultaneously. state-mate will automatically detect which format you're using.
 
@@ -165,6 +185,16 @@ To download only missing ABIs (without updating existing ones):
 
 ```sh
 yarn start path/to/config.yaml --update-abi-missing
+```
+
+### Scoping checks
+
+Use `-o` to run only part of a config. The path drills in from network section to contract to a single function:
+
+```sh
+yarn start path/to/config.yaml -o l1                          # one network section
+yarn start path/to/config.yaml -o l1/myContract               # one contract
+yarn start path/to/config.yaml -o l1/myContract/checks/getFoo # one check
 ```
 
 ## 🔧 Contributing

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "start": "ts-node -r tsconfig-paths/register src/state-mate.ts",
-    "consolidate-abi": "sh -c 'ts-node src/consolidate-abis.ts \"$1\" --compress' --",
+    "consolidate-abi": "ts-node src/consolidate-abis.ts",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "yarn lint --fix",
     "format": "prettier . --ignore-path .gitignore --ignore-path .prettierignore --check",

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -43,13 +43,16 @@ export function parseCmdLineArguments() {
     };
   }
 
+  // On --generate, download missing ABIs by default (skip existing), unless --update-abi overwrites all.
+  const updateAbiMissingOnly = options.updateAbiMissing || (options.generate && !options.updateAbi);
+
   return {
     configPath,
     abiDirPath: path.join(path.dirname(configPath), "abi"),
     checkOnly,
     checkOnlyCmdArg: options.only,
     generate: options.generate,
-    updateAbi: options.updateAbi || options.updateAbiMissing,
-    updateAbiMissingOnly: options.updateAbiMissing,
+    updateAbi: options.updateAbi || updateAbiMissingOnly,
+    updateAbiMissingOnly,
   };
 }

--- a/src/consolidate-abis.ts
+++ b/src/consolidate-abis.ts
@@ -11,10 +11,10 @@ interface ConsolidatedAbis {
 function parseArguments(): { abiDirectoryPath: string; shouldCompress: boolean } {
   const arguments_ = process.argv.slice(2);
   const abiDirectoryPath = arguments_[0];
-  const shouldCompress = arguments_.includes("--compress");
+  const shouldCompress = !arguments_.includes("--no-compress");
 
   if (!abiDirectoryPath) {
-    console.error("Usage: ts-node src/consolidate-abis.ts <abi-directory-path> [--compress]");
+    console.error("Usage: ts-node src/consolidate-abis.ts <abi-directory-path> [--no-compress]");
     process.exit(1);
   }
 


### PR DESCRIPTION
This pull request improves the documentation and user experience for configuring and running state-mate, clarifies best practices, and updates script and argument handling for ABI consolidation and config generation. The changes focus on making setup steps clearer, improving consistency in the documentation, and ensuring ABI management is more intuitive.

**Documentation and Setup Improvements:**

* The `README.md` now provides clearer, step-by-step instructions for configuring `.env`, setting up RPC endpoints, explorer tokens, and generating configs. It also documents scoping checks with the `-o` flag and clarifies ABI storage and consolidation options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R98) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126-R128) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R146) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R173) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R190-R199)

**Script and CLI Behavior Changes:**

* The `yarn consolidate-abi` script and `src/consolidate-abis.ts` now default to compressed output (`abis.json.gz`), with an option for uncompressed output via `--no-compress`. Usage instructions are updated accordingly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14) [[2]](diffhunk://#diff-3667fed3e62e540626523c78ffa1fef63981f837209c07c62d8c0f27974c8cdcL14-R17)
* The CLI parser (`src/cli-parser.ts`) now automatically downloads missing ABIs on `--generate` unless `--update-abi` is specified, making ABI management more user-friendly and predictable.

**Skill Documentation Consistency:**

* The `.claude/skills/state-mate/skill.md` file has been edited for clarity, consistency, and improved explanations, including better section descriptions, clearer best practices, and more readable instructions for common tasks and troubleshooting. [[1]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL3-R3) [[2]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL26-R26) [[3]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL49-R49) [[4]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL63-R63) [[5]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL100-R100) [[6]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL173-R173) [[7]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL244-R244) [[8]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL322-R328) [[9]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL349-R351) [[10]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL363-R372) [[11]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL397-R402) [[12]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL414-R415) [[13]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL425-R425) [[14]](diffhunk://#diff-9aaa0d4e4e9ba514d959d0e8bd545c75be7db62915114945ca525f9a5268fcdeL437-R437)

No functional code changes were made to the core logic; all changes are related to documentation, scripts, and CLI argument handling to improve developer experience.