### PR TITLE
fix: sync earn fees and mellow merkle root with onchain state

### DIFF
--- a/configs/earn/ethereum/earneth-vaults.yaml
+++ b/configs/earn/ethereum/earneth-vaults.yaml
@@ -1312,8 +1312,8 @@ l1:
         feeRecipient: *treasury
         minPriceD18:
         owner: *lazyVaultAdmin
-        performanceFeeD6: 0
-        protocolFeeD6: 0
+        performanceFeeD6: 100000
+        protocolFeeD6: 10000
         redeemFeeD6: 0
         timestamps:
       implementationChecks:

--- a/configs/earn/ethereum/earnusd-vaults.yaml
+++ b/configs/earn/ethereum/earnusd-vaults.yaml
@@ -1158,8 +1158,8 @@ l1:
         feeRecipient: *treasury
         minPriceD18:
         owner: *lazyVaultAdmin
-        performanceFeeD6: 0
-        protocolFeeD6: 0
+        performanceFeeD6: 100000
+        protocolFeeD6: 10000
         redeemFeeD6: 0
         timestamps:
       implementationChecks:
@@ -2438,7 +2438,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0x6684dd40de98004314146ec0e664da87cee9a0b83993df2e13cfac91f003559e"
+        merkleRoot: "0x92cf8cbe6034ade3bb247df86672b570f9bee9e74e10f011fc2af8fc2fd44785"
         vault: *earnUSDe_vault
         verifyCall:
       implementationChecks:

--- a/configs/earn/mantle/earnusd-vaults.yaml
+++ b/configs/earn/mantle/earnusd-vaults.yaml
@@ -997,7 +997,7 @@ l1:
           - *EXT_MELLOW_SIGNER_2
           - *MELLOW_SIGNER_2
           - *MELLOW_SIGNER_3
-          - *MELLOW_SIGNER_1
+          - *EXT_MELLOW_SIGNER_1
           - *MELLOW_SIGNER_4
           - *EXT_MELLOW_SIGNER_4
         getStorageAt:

--- a/configs/mellow_strategy/mellow-strategy.yaml
+++ b/configs/mellow_strategy/mellow-strategy.yaml
@@ -2020,7 +2020,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0x0defb6ee7a9988e2247999be4b92bbcfff0ef4bcaf98a4e1f7e665e805c129a5"
+        merkleRoot: "0xa61ed3d1075e5942cc35956b9efd3bb1b67059785115a7cb6728ae77f42c7b10"
         vault: *vault
         verifyCall:
       implementationChecks:


### PR DESCRIPTION
CI drifted from mainnet state this week. Updated expected values to match onchain:

- `earn/ethereum/earnusd-vaults.yaml` — `earnUSD_feeManager` (0x72fa23f40e08eB9E45953233b2Dd9665E347e8Dc): performanceFeeD6 = 100000, protocolFeeD6 = 10000
- `earn/ethereum/earnusd-vaults.yaml` — `earnUSDe_verifier0` (0x87631dbf0224234107B593c874f63f577e1336Da): merkleRoot = 0x92cf8cbe6034ade3bb247df86672b570f9bee9e74e10f011fc2af8fc2fd44785
- `earn/ethereum/earneth-vaults.yaml` — `feeManager` (0xed4Fac879eE86F3aB0101993A3713e7cAA0488E1): performanceFeeD6 = 100000, protocolFeeD6 = 10000
- `mellow_strategy/mellow-strategy.yaml` — `verifier2` (0x1616d39a201D246cbD1B3B145234638f7719b53A): merkleRoot = 0xa61ed3d1075e5942cc35956b9efd3bb1b67059785115a7cb6728ae77f42c7b10
- `earn/mantle/earnusd-vaults.yaml` — `curator_multisig` (0x9745F161b0160a99924845BeFCE1d7b9Daee6899): owner 0x44A388BBD782AE1D7f4542aEb6C3569E2CfdF5a1 replaced with 0x78Eb634731bE1957D370BEcbbD254F427Af5D13b (MELLOW_SIGNER_1 → EXT_MELLOW_SIGNER_1)

All checks verified locally against live chains via public RPC.