### PR TITLE
Feat: improve skill & fix proxy ABI detection

### DIFF
--- a/.claude/skills/state-mate/references/verification-playbook.md
+++ b/.claude/skills/state-mate/references/verification-playbook.md
@@ -1,0 +1,86 @@
+# Deployment verification playbook
+
+How to verify that a deployment is correct and honest: constants recompute from their claimed sources, implementations are neutered, temporary addresses hold no roles. Use it when reviewing a config for a fresh deployment (pre-vote state, upgrade audit), not for routine config edits.
+
+A config passing against the chain only proves "config == chain". The steps below prove "chain == what was intended".
+
+**Re-running the config is the primary instrument.** Anything provable as a config check must become one: a check re-runs on every change and in CI, while a one-off `cast` call proves nothing after the session ends. Read on-chain values with REPLACEME runs. The strongest single re-run: delete the ABI archive, re-fetch with `--update-abi-missing`, full run. That verifies the config against freshly verified source in one shot. Reserve `cast` for what a config run cannot express (section A).
+
+## A. What a config run cannot express (once per review)
+
+Don't trust a comment or a copy-pasted constant: recompute it.
+
+- **Role hashes**: recompute every `bytes32` hash against its claimed source with `cast keccak "ROLE_NAME"`.
+- **Addresses**: `cast to-checksum $ADDR` must return every address unchanged (EIP-55). Catches single-character tampering.
+- **Namespaced storage slots**: for constants like `keccak256("project.Contract.varName")`, reconstruct the dotted string and recompute. Document the formula in a comment once verified.
+- **Domain-bound constants** (hashes that embed chainId and/or the contract's own address, e.g. signed-message prefixes): reconstruct the derivation and recompute. This proves the value binds to the right network and the right contract instance.
+- **ABI vs bytecode**: `cast selectors "$(cast code $ADDR --rpc-url $RPC)"`. Every selector in the dispatch table must match the ABI and vice versa. Catches hidden functions and incomplete ABIs.
+- **Numeric parameters**: cross-check against the external deploy document, not just the chain. The config and the chain can both carry the same wrong value. Flag any value with no documented source.
+- **Identify every role holder**: `cast code` (EOA vs contract), `VERSION()(string)` (Safe detection), then match against docs and sibling configs. Flag unidentified holders to the deploy team instead of legitimizing them by pinning.
+- **`initialize()` on bare implementations**: simulate with `cast call` (plain eth_call, no transaction needed) and expect the init-guard revert (OZ 5.x: `InvalidInitialization`, selector `0xf92ee8a9`). state-mate cannot check this (the function is nonpayable). Note the result in a review comment, not a config comment.
+
+## B. Checks to encode in the config
+
+### Live contracts with AccessControl
+
+- `ozAcl` with exhaustive per-role member lists, including empty roles as `[]`.
+- `getRoleAdmin(role) == DEFAULT_ADMIN_ROLE` for every role. Catches a `_setRoleAdmin` backdoor: a custom admin role lets someone grant roles bypassing the real admin.
+
+```yaml
+checks:
+  getRoleAdmin:
+    - args: [*SOME_ROLE]
+      result: *DEFAULT_ADMIN_ROLE
+```
+
+- Explicit `hasRole(DEFAULT_ADMIN_ROLE, <deploy tooling / temporary admin>) == false`: temporary admin renounced.
+- Skip standalone `getRoleMemberCount` checks: `ozAcl` already verifies the count and each member.
+
+### Gnosis Safe (committees)
+
+- Model the stanza as a proxy: `name: Safe` (singleton ABI), `proxyName: SafeProxy`, `implementation:` the canonical singleton (see the Gnosis Safe pattern in SKILL.md).
+- `VERSION`, `getThreshold`, and the full `getOwners` list. A composition change must break the run. Check every owner is what you expect (EOA vs contract) with `cast code`.
+- Pin the module list to empty: a Safe module executes transactions bypassing owner signatures.
+- Pin the takeover-surface storage slots via `storage:`: slot `0x0` == the canonical Safe singleton for that version; `keccak("fallback_manager.handler.address")` == the canonical CompatibilityFallbackHandler (a malicious handler runs code as the Safe); `keccak("guard_manager.guard.address")` == zero unless a guard is documented.
+
+```yaml
+checks:
+  getModulesPaginated:
+    - args: ["0x0000000000000000000000000000000000000001", 10]
+      result: [[], "0x0000000000000000000000000000000000000001"]
+```
+
+### Implementations
+
+Put these in `implementationChecks:` inside the proxy stanza, not in a separate contract stanza. It auto-covers unlisted view functions as skipped.
+
+- **Petrification sentinel**, the one check that answers "can this impl be hijacked":
+  - OZ Initializable: version getter == max value of its type (`MAX_UINT256` / `MAX_UINT64`).
+  - Aragon apps: `isPetrified: true`, `getInitializationBlock` == `MAX_UINT256`, kernel == zero address.
+  - No sentinel getter at all: only the eth_call simulation from section A proves it.
+- **Immutables == production values.** Constructor-baked wiring (addresses, ids) proves deploy parameters were right. Harvest actuals with REPLACEME; they equal the proxy's values, since immutables live in bytecode.
+- **Everything set by `initialize` == zeros/defaults.**
+- `hasRole(DEFAULT_ADMIN_ROLE, <the proxy's admin>) == false`: the distinguishing zero check. The admin holds the role on the proxy but must not on the bare impl.
+- Role-hash constant getters are bytecode, not state. They say nothing about neutering: any deploy of the same code returns the same value.
+
+### Pre-state pins (before a vote / enactment)
+
+Pin empty registries and unassigned pairs with explicit arg checks, so premature configuration breaks the run:
+
+```yaml
+checks:
+  getAllowedTargets:
+    - args: [1]
+      result: []
+  isPairAllowed:
+    - args: [1, 1]
+      result: false
+```
+
+## C. Config organization
+
+- Sections by purpose: `parameters:` holds network system predeploys only; `deployed:` the contract address book; `misc:` numeric/bytes32 constants; `roles:` role hashes; `eoa:` EOAs.
+- Name anchors by meaning, not by value (`&MIN_DEPOSIT`, not `&THIRTY_TWO_ETH_WEI`). Two anchors may share a value when semantics differ.
+- Give predeploys a suffix (e.g. `_CONTRACT`) so the anchor doesn't shadow a same-named check key.
+- Put a reproduction comment (`# cast keccak "..."`) above every verifiable hash.
+- Hoist repeated values into anchors; single-use data literals may stay inline. Group stateless libraries at the bottom of `contracts:`.

--- a/.claude/skills/state-mate/skill.md
+++ b/.claude/skills/state-mate/skill.md
@@ -1,6 +1,6 @@
 ---
 name: state-mate
-description: Configure and verify state-mate YAML for EVM smart-contract state checks — contracts, proxies (Transparent, Ossifiable, AppProxyUpgradeable), Safe multisigs, ozAcl and ozNonEnumerableAcl access control, ABI resolution and updates, EIP-1967 storage slots, seed configs and --generate, REPLACEME discovery, and common error triage.
+description: Use this skill when writing, debugging, or reviewing state-mate YAML configs that verify on-chain EVM contract state — proxy patterns and their storage, multisig wallets, role-based access control, ABI resolution, generating starter configs, and discovering unknown on-chain values. Also applies when verifying or auditing a deployment against a config: pre-vote state review, role audit, checking that implementations are neutered and constants aren't forged. Applies even when the user just says a check is failing or asks to add a contract to an existing config, without naming state-mate explicitly.
 ---
 
 # State-Mate Skill
@@ -9,16 +9,17 @@ Validate EVM smart-contract state against YAML configs. state-mate calls view fu
 
 ## Pick a section
 
-| Task                                                   | Go to                                                              |
-| ------------------------------------------------------ | ------------------------------------------------------------------ |
-| New config from scratch                                | [Top-level structure](#top-level-structure), [Workflow](#workflow) |
-| Contract with a proxy                                  | [Proxy patterns](#proxy-patterns)                                  |
-| Multisig checks                                        | [Gnosis Safe](#gnosis-safe)                                        |
-| Role/ACL checks                                        | [Access control](#access-control)                                  |
-| Unknown return values                                  | [REPLACEME discovery](#replaceme-discovery)                        |
-| Overloaded function (two ABI fragments with same name) | [Function overloads](#function-overloads)                          |
-| Seed config (`--generate`)                             | [Seed configs](#seed-configs)                                      |
-| ABI not found / rate-limit / revert reading            | [Troubleshooting](#troubleshooting)                                |
+| Task                                                    | Go to                                                              |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| New config from scratch                                 | [Top-level structure](#top-level-structure), [Workflow](#workflow) |
+| Contract with a proxy                                   | [Proxy patterns](#proxy-patterns)                                  |
+| Multisig checks                                         | [Gnosis Safe](#gnosis-safe)                                        |
+| Role/ACL checks                                         | [Access control](#access-control)                                  |
+| Unknown return values                                   | [REPLACEME discovery](#replaceme-discovery)                        |
+| Overloaded function (two ABI fragments with same name)  | [Function overloads](#function-overloads)                          |
+| Seed config (`--generate`)                              | [Seed configs](#seed-configs)                                      |
+| ABI not found / rate-limit / revert reading             | [Troubleshooting](#troubleshooting)                                |
+| Deployment verification / audit (pre-vote state, roles) | Read `references/verification-playbook.md`                         |
 
 ## Top-level structure
 
@@ -46,11 +47,11 @@ roles: # bytes32 role hashes, often many (one per domain)
 eoa: # named EOAs (deployer, signer addresses); useful for "deployer renounced" checks
   - &deployer "0x..."
 
-l1: # per-chain section — key matches deployed.* key
+l1: # per-chain section — literal key name, not the chain's own name
   rpcUrl: L1_MAINNET_RPC_URL # env-var name, or inline URL
   explorerHostname: api.etherscan.io/v2/api
   explorerTokenEnv: ETHERSCAN_TOKEN
-  chainId: 1
+  chainId: 1 # number or string
   contracts:
     contractName:
       # ...
@@ -60,7 +61,9 @@ l2: # present when deployed.l2 exists
   # ...
 ```
 
-`parameters`, `deployed`, `misc`, `roles`, `eoa` are anchor-only sections — they define YAML anchors (`&name`) that later sections reference via `*name`. Only `<chain-key>` sections with `contracts:` produce on-chain calls.
+`parameters`, `deployed`, `misc`, `roles`, `eoa` are anchor-only sections — they define YAML anchors (`&name`) that later sections reference via `*name`. `deployed-aux`, `tvl`, `delays`, `signers`, `selectors`, `validators` are optional anchor-only sections too, same shape as `misc`. Only `<chain-key>` sections with `contracts:` produce on-chain calls.
+
+`deployed` and the per-chain sections accept exactly two keys: `l1` (required) and `l2` (optional) — fixed schema literals, not placeholders for the actual network's name. A config for a single L2 chain still uses `l1:`, never the chain's own name.
 
 ## Contract patterns
 
@@ -77,7 +80,7 @@ contractName:
 
 ### Proxy patterns
 
-**Transparent Upgradeable Proxy** (OpenZeppelin classic). `proxyChecks: {}` because the admin/impl live in EIP-1967 slots, which you verify via `storage:`:
+**Transparent Upgradeable Proxy**. `proxyChecks: {}` because the admin/impl live in EIP-1967 slots, which you verify via `storage:`:
 
 ```yaml
 contractName:
@@ -110,7 +113,7 @@ contractName:
   proxyName: OssifiableProxy
   implementation: *implAddress
   proxyChecks:
-    proxy__getAdmin: *aragonAgent
+    proxy__getAdmin: *proxyAdminAddress
     proxy__getImplementation: *implAddress
     proxy__getIsOssified: false
   checks:
@@ -119,20 +122,20 @@ contractName:
     someFunction: *ZERO_ADDRESS
 ```
 
-**AppProxyUpgradeable** (Aragon apps) has its own shape:
+**AppProxyUpgradeable** has its own shape:
 
 ```yaml
 contractName:
-  name: Lido
-  address: *lido
+  name: ContractName
+  address: *contractAddress
   proxyName: AppProxyUpgradeable
-  implementation: *lidoImplAddress
+  implementation: *implAddress
   proxyChecks:
     proxyType: *PROXY_TYPE_APP_PROXY_UPGRADEABLE
     isDepositable: false
-    implementation: *lidoImplAddress
-    appId: *LIDO_APP_ID
-    kernel: *aragonKernel
+    implementation: *implAddress
+    appId: *APP_ID
+    kernel: *kernelAddress
 ```
 
 ### ProxyAdmin
@@ -155,10 +158,19 @@ cast call $ADDRESS "VERSION()(string)" --rpc-url $RPC
 # Safe → returns "1.4.1"; EOA or non-Safe → reverts
 ```
 
+A Safe is a SafeProxy delegating to a singleton — model it as a proxy. `name:` is the singleton contract (its ABI carries all view functions); SafeProxy exposes no view functions (`masterCopy()` is a fallback trick absent from the ABI), so `proxyChecks: {}` and the linkage is verified via slot 0:
+
 ```yaml
 multisigName:
-  name: GnosisSafe
+  name: Safe # GnosisSafe for pre-1.3.0 deployments
   address: *multisigAddress
+  proxyName: SafeProxy
+  implementation: *safeSingleton # canonical singleton for that version
+  proxyChecks: {}
+  storage:
+    - slot: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      expected: *safeSingleton
+      label: singleton
   checks:
     VERSION: "1.4.1"
     getThreshold: *THRESHOLD_VALUE
@@ -260,9 +272,9 @@ When the ABI has two fragments with the same name, state-mate needs disambiguati
 ```yaml
 checks:
   domainSeparatorV4:
-    - args: [*lido]
+    - args: [*contractAddress]
       signature: "domainSeparatorV4(address)"
-      result: *LIDO_DOMAIN_SEPARATOR
+      result: *DOMAIN_SEPARATOR
 ```
 
 ## Access control
@@ -346,14 +358,14 @@ cast call $CONTRACT "hasRole(bytes32,address)(bool)" $ROLE $ADDRESS --rpc-url $R
 
 ## Seed configs
 
-A seed config is a thin starter file named `*.seed.yml`. It contains only address-book and chain-explorer sections (`deployed:`, `l1:` / `l2:` with `rpcUrl` / `explorerHostname`, optional `eoa:` / `roles:` / `misc:`) — **no `contracts:` block**. `yarn start <seed> --generate` walks every anchor under `deployed:`, resolves the ABI for each address, and writes a sibling `*.seed.generated.yml` with a populated `contracts:` block where each function value is `REPLACEME` (and, for proxies, a commented-out `implementationChecks` stub).
+A seed config is a thin starter file named `*.seed.yaml`. It contains only address-book and chain-explorer sections (`deployed:`, `l1:` / `l2:` with `rpcUrl` / `explorerHostname`, optional `eoa:` / `roles:` / `misc:`) — **no `contracts:` block**. `yarn start <seed> --generate` walks every anchor under `deployed:`, resolves the ABI for each address, and writes a sibling `*.seed.generated.yaml` with a populated `contracts:` block where each function value is `REPLACEME` (and, for proxies, a commented-out `implementationChecks` stub).
 
 `--generate` on its own does not fetch ABIs — it only uses ABIs already on disk. Combine with `--update-abi-missing` on first run.
 
 ```bash
-yarn start configs/proto/mainnet.seed.yml --generate --update-abi-missing
-# Review *.seed.generated.yml, replace REPLACEME with real expectations, then:
-yarn start configs/proto/mainnet.seed.generated.yml
+yarn start configs/proto/mainnet.seed.yaml --generate --update-abi-missing
+# Review *.seed.generated.yaml, replace REPLACEME with real expectations, then:
+yarn start configs/proto/mainnet.seed.generated.yaml
 ```
 
 ## Workflow
@@ -389,7 +401,7 @@ yarn start config.yml -o l1/contractName                  # specific contract (g
 yarn start config.yml -o l1/contractName/checks/funcName  # single function
 yarn start config.yml --update-abi-missing                # download only missing ABIs (preferred)
 yarn start config.yml --update-abi                        # overwrite all ABIs (rarely needed)
-yarn start config.seed.yml --generate                     # expand seed → *.seed.generated.yml
+yarn start config.seed.yaml --generate                    # expand seed → *.seed.generated.yaml
 ```
 
 ## Best practices
@@ -413,6 +425,10 @@ yarn start config.seed.yml --generate                     # expand seed → *.se
 
 - The contract is standard AccessControl, not Enumerable — switch to `ozNonEnumerableAcl:` or raw `hasRole` checks.
 - Or the contract doesn't expose role management at all — skip the role block.
+
+### `Non-covered functions: ...`
+
+- `checks:` must list every view function of the ABI (unknown ones as `null`). `implementationChecks:` doesn't have this requirement: it auto-fills unlisted functions as skipped.
 
 ### `missing revert data` with `data=null`
 

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -417,25 +417,26 @@ export function resetAbiModeCache(): void {
   g_abiMode = null;
 }
 
+type FindAbiOptions = { shouldThrow?: boolean; allowAddressFallback?: boolean };
+
 function _findAbiPath(
   contractName: string,
   contractAddress: string,
-  shouldThrow: { shouldThrow: true; allowAddressFallback?: boolean },
+  options: FindAbiOptions & { shouldThrow: true },
 ): string;
 
 function _findAbiPath(
   contractName: string,
   contractAddress: string,
-  shouldThrow?: { shouldThrow: false; allowAddressFallback?: boolean },
+  options?: FindAbiOptions & { shouldThrow?: false },
 ): string | null;
 
-function _findAbiPath(
-  contractName: string,
-  contractAddress: string,
-  { shouldThrow, allowAddressFallback = true }: { shouldThrow?: boolean; allowAddressFallback?: boolean } = {
-    shouldThrow: false,
-  },
-): string | null {
+function _findAbiPath(contractName: string, contractAddress: string, options: FindAbiOptions = {}): string | null {
+  // allowAddressFallback defaults to false: matching by address alone can return a file named
+  // after another contract (e.g. the proxy's own ABI), which must never be picked implicitly,
+  // and never overwritten when saving. Readers opt in explicitly.
+  const { shouldThrow = false, allowAddressFallback = false } = options;
+
   if (!contractName || !g_Arguments.abiDirPath) return null;
 
   // prettier-ignore

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -437,7 +437,12 @@ function _findAbiPath(contractName: string, contractAddress: string, options: Fi
   // and never overwritten when saving. Readers opt in explicitly.
   const { shouldThrow = false, allowAddressFallback = false } = options;
 
-  if (!contractName || !g_Arguments.abiDirPath) return null;
+  if (!contractName || !g_Arguments.abiDirPath) {
+    if (shouldThrow) {
+      throw new Error(`ABI lookup failed: ${contractName ? "ABI directory path is not set" : "empty contract name"}`);
+    }
+    return null;
+  }
 
   // prettier-ignore
   const abiVariantsName = [

--- a/src/boilerplate-generator.ts
+++ b/src/boilerplate-generator.ts
@@ -16,7 +16,7 @@ import { ContractEntry, EntireDocument, ExplorerSectionTB, isTypeOfTB, NetworkSe
 import { MethodCallResults, Abi } from "./types";
 
 const REPLACE_ME_PLACEHOLDER = "REPLACEME";
-const YML = "yml";
+const YAML_EXT = "yaml";
 const MAIN_SCHEMA_NAME = "main-schema.json";
 
 export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument: SeedDocument) {
@@ -100,7 +100,7 @@ export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument
 
   const generatedFilePath = path.join(
     path.dirname(seedConfigPath),
-    `${path.basename(seedConfigPath, "." + YML)}.generated.${YML}`,
+    `${path.basename(seedConfigPath, "." + YAML_EXT)}.generated.${YAML_EXT}`,
   );
   writeGeneratedYaml(generatedFilePath, document.toString());
 }

--- a/src/boilerplate-generator.ts
+++ b/src/boilerplate-generator.ts
@@ -16,7 +16,6 @@ import { ContractEntry, EntireDocument, ExplorerSectionTB, isTypeOfTB, NetworkSe
 import { MethodCallResults, Abi } from "./types";
 
 const REPLACE_ME_PLACEHOLDER = "REPLACEME";
-const YAML_EXT = "yaml";
 const MAIN_SCHEMA_NAME = "main-schema.json";
 
 export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument: SeedDocument) {
@@ -98,9 +97,10 @@ export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument
     sectionNode.addIn([EntryField.contracts], new YAML.Pair(context.deployedNode.anchor, contractEntry));
   });
 
+  const extension = path.extname(seedConfigPath);
   const generatedFilePath = path.join(
     path.dirname(seedConfigPath),
-    `${path.basename(seedConfigPath, "." + YAML_EXT)}.generated.${YAML_EXT}`,
+    `${path.basename(seedConfigPath, extension)}.generated${extension}`,
   );
   writeGeneratedYaml(generatedFilePath, document.toString());
 }


### PR DESCRIPTION
- Skill: deployment verification playbook (`references/verification-playbook.md`), refreshed patterns, Safe-as-proxy stanza, troubleshooting.
- `_findAbiPath`: address fallback now opt-in. Etherscan resolves proxy addresses to implementation ABIs, and the old default let the impl ABI overwrite `OssifiableProxy-*.json` on `--update-abi`. Also honours `shouldThrow` in the early exit.
- `--generate`: strips the real seed extension, so `.yml` seeds no longer produce `x.seed.yml.generated.yaml`.
- eslint-plugin-unicorn v69 (merged in #144) left `yarn lint` with 122 errors: 33 fixed in code, 9 opinionated rules disabled with reasons in `eslint.config.mjs`.
- CI on Node 22: unicorn v69 calls `Set.prototype.union`, absent on Node 20 runners.
- yarn 4.17: install scripts gated behind a `dependenciesMeta` whitelist (`unrs-resolver` only), npm age gate kept at default.

Validation: `yarn lint` and `yarn format` clean, `lido.yaml -o l1/lidoLocator` against a mainnet fork passes 51/51.