### PR TITLE
Feat: improve skill

### DIFF
--- a/.claude/skills/state-mate/references/verification-playbook.md
+++ b/.claude/skills/state-mate/references/verification-playbook.md
@@ -1,0 +1,86 @@
+# Deployment verification playbook
+
+How to verify that a deployment is correct and honest: constants recompute from their claimed sources, implementations are neutered, temporary addresses hold no roles. Use it when reviewing a config for a fresh deployment (pre-vote state, upgrade audit), not for routine config edits.
+
+A config passing against the chain only proves "config == chain". The steps below prove "chain == what was intended".
+
+**Re-running the config is the primary instrument.** Anything provable as a config check must become one: a check re-runs on every change and in CI, while a one-off `cast` call proves nothing after the session ends. Read on-chain values with REPLACEME runs. The strongest single re-run: delete the ABI archive, re-fetch with `--update-abi-missing`, full run. That verifies the config against freshly verified source in one shot. Reserve `cast` for what a config run cannot express (section A).
+
+## A. What a config run cannot express (once per review)
+
+Don't trust a comment or a copy-pasted constant: recompute it.
+
+- **Role hashes**: recompute every `bytes32` hash against its claimed source with `cast keccak "ROLE_NAME"`.
+- **Addresses**: `cast to-checksum $ADDR` must return every address unchanged (EIP-55). Catches single-character tampering.
+- **Namespaced storage slots**: for constants like `keccak256("project.Contract.varName")`, reconstruct the dotted string and recompute. Document the formula in a comment once verified.
+- **Domain-bound constants** (hashes that embed chainId and/or the contract's own address, e.g. signed-message prefixes): reconstruct the derivation and recompute. This proves the value binds to the right network and the right contract instance.
+- **ABI vs bytecode**: `cast selectors "$(cast code $ADDR --rpc-url $RPC)"`. Every selector in the dispatch table must match the ABI and vice versa. Catches hidden functions and incomplete ABIs.
+- **Numeric parameters**: cross-check against the external deploy document, not just the chain. The config and the chain can both carry the same wrong value. Flag any value with no documented source.
+- **Identify every role holder**: `cast code` (EOA vs contract), `VERSION()(string)` (Safe detection), then match against docs and sibling configs. Flag unidentified holders to the deploy team instead of legitimizing them by pinning.
+- **`initialize()` on bare implementations**: simulate with `cast call` (plain eth_call, no transaction needed) and expect the init-guard revert (OZ 5.x: `InvalidInitialization`, selector `0xf92ee8a9`). state-mate cannot check this (the function is nonpayable). Note the result in a review comment, not a config comment.
+
+## B. Checks to encode in the config
+
+### Live contracts with AccessControl
+
+- `ozAcl` with exhaustive per-role member lists, including empty roles as `[]`.
+- `getRoleAdmin(role) == DEFAULT_ADMIN_ROLE` for every role. Catches a `_setRoleAdmin` backdoor: a custom admin role lets someone grant roles bypassing the real admin.
+
+```yaml
+checks:
+  getRoleAdmin:
+    - args: [*SOME_ROLE]
+      result: *DEFAULT_ADMIN_ROLE
+```
+
+- Explicit `hasRole(DEFAULT_ADMIN_ROLE, <deploy tooling / temporary admin>) == false`: temporary admin renounced.
+- Skip standalone `getRoleMemberCount` checks: `ozAcl` already verifies the count and each member.
+
+### Gnosis Safe (committees)
+
+- Model the stanza as a proxy: `name: Safe` (singleton ABI), `proxyName: SafeProxy`, `implementation:` the canonical singleton (see the Gnosis Safe pattern in SKILL.md).
+- `VERSION`, `getThreshold`, and the full `getOwners` list. A composition change must break the run. Check every owner is what you expect (EOA vs contract) with `cast code`.
+- Pin the module list to empty: a Safe module executes transactions bypassing owner signatures.
+- Pin the takeover-surface storage slots via `storage:`: slot `0x0` == the canonical Safe singleton for that version; `keccak("fallback_manager.handler.address")` == the canonical CompatibilityFallbackHandler (a malicious handler runs code as the Safe); `keccak("guard_manager.guard.address")` == zero unless a guard is documented.
+
+```yaml
+checks:
+  getModulesPaginated:
+    - args: ["0x0000000000000000000000000000000000000001", 10]
+      result: [[], "0x0000000000000000000000000000000000000001"]
+```
+
+### Implementations
+
+Put these in `implementationChecks:` inside the proxy stanza, not in a separate contract stanza. It auto-covers unlisted view functions as skipped.
+
+- **Petrification sentinel**, the one check that answers "can this impl be hijacked":
+  - OZ Initializable: version getter == max value of its type (`MAX_UINT256` / `MAX_UINT64`).
+  - Aragon apps: `isPetrified: true`, `getInitializationBlock` == `MAX_UINT256`, kernel == zero address.
+  - No sentinel getter at all: only the eth_call simulation from section A proves it.
+- **Immutables == production values.** Constructor-baked wiring (addresses, ids) proves deploy parameters were right. Harvest actuals with REPLACEME; they equal the proxy's values, since immutables live in bytecode.
+- **Everything set by `initialize` == zeros/defaults.**
+- `hasRole(DEFAULT_ADMIN_ROLE, <the proxy's admin>) == false`: the distinguishing zero check. The admin holds the role on the proxy but must not on the bare impl.
+- Role-hash constant getters are bytecode, not state. They say nothing about neutering: any deploy of the same code returns the same value.
+
+### Pre-state pins (before a vote / enactment)
+
+Pin empty registries and unassigned pairs with explicit arg checks, so premature configuration breaks the run:
+
+```yaml
+checks:
+  getAllowedTargets:
+    - args: [1]
+      result: []
+  isPairAllowed:
+    - args: [1, 1]
+      result: false
+```
+
+## C. Config organization
+
+- Sections by purpose: `parameters:` holds network system predeploys only; `deployed:` the contract address book; `misc:` numeric/bytes32 constants; `roles:` role hashes; `eoa:` EOAs.
+- Name anchors by meaning, not by value (`&MIN_DEPOSIT`, not `&THIRTY_TWO_ETH_WEI`). Two anchors may share a value when semantics differ.
+- Give predeploys a suffix (e.g. `_CONTRACT`) so the anchor doesn't shadow a same-named check key.
+- Put a reproduction comment (`# cast keccak "..."`) above every verifiable hash.
+- Hoist repeated values into anchors; single-use data literals may stay inline. Group stateless libraries at the bottom of `contracts:`.

--- a/.claude/skills/state-mate/skill.md
+++ b/.claude/skills/state-mate/skill.md
@@ -71,7 +71,7 @@ l2: # present when deployed.l2 exists
 
 ```yaml
 contractName:
-  name: ContractName                 # must match ABI filename
+  name: ContractName # must match ABI filename
   address: *contractAddress
   checks:
     functionName: expectedValue
@@ -198,7 +198,7 @@ checks:
     - args: [1]
       result: *item2
     - args: [2]
-      mustRevert: true        # out of bounds
+      mustRevert: true # out of bounds
 ```
 
 Multi-arg indexed getter:
@@ -286,8 +286,8 @@ Use when `getRoleMemberCount(bytes32)` succeeds:
 ```yaml
 ozAcl:
   *DEFAULT_ADMIN_ROLE : [*adminAddress]
-  *SOME_ROLE          : [*holder1, *holder2]
-  *UNUSED_ROLE        : []             # explicit: 0 members
+  *SOME_ROLE : [*holder1, *holder2]
+  *UNUSED_ROLE : [] # explicit: 0 members
 ```
 
 ### Non-enumerable AccessControl → `ozNonEnumerableAcl:`
@@ -296,8 +296,8 @@ Same shape as `ozAcl`, but state-mate verifies via per-address `hasRole` instead
 
 ```yaml
 ozNonEnumerableAcl:
-  *DEFAULT_ADMIN_ROLE      : [*agent]
-  *DEPOSITS_ENABLER_ROLE   : [*agent]
+  *DEFAULT_ADMIN_ROLE : [*agent]
+  *DEPOSITS_ENABLER_ROLE : [*agent]
   *WITHDRAWALS_DISABLER_ROLE : [*agent, *emergencyMultisig]
 ```
 

--- a/.claude/skills/state-mate/skill.md
+++ b/.claude/skills/state-mate/skill.md
@@ -1,6 +1,6 @@
 ---
 name: state-mate
-description: Configure and verify state-mate YAML for EVM smart-contract state checks — contracts, proxies (Transparent, Ossifiable, AppProxyUpgradeable), Safe multisigs, ozAcl and ozNonEnumerableAcl access control, ABI resolution and updates, EIP-1967 storage slots, seed configs and --generate, REPLACEME discovery, and common error triage.
+description: Use this skill when writing, debugging, or reviewing state-mate YAML configs that verify on-chain EVM contract state — proxy patterns and their storage, multisig wallets, role-based access control, ABI resolution, generating starter configs, and discovering unknown on-chain values. Also applies when verifying or auditing a deployment against a config: pre-vote state review, role audit, checking that implementations are neutered and constants aren't forged. Applies even when the user just says a check is failing or asks to add a contract to an existing config, without naming state-mate explicitly.
 ---
 
 # State-Mate Skill
@@ -9,16 +9,17 @@ Validate EVM smart-contract state against YAML configs. state-mate calls view fu
 
 ## Pick a section
 
-| Task                                                   | Go to                                                              |
-| ------------------------------------------------------ | ------------------------------------------------------------------ |
-| New config from scratch                                | [Top-level structure](#top-level-structure), [Workflow](#workflow) |
-| Contract with a proxy                                  | [Proxy patterns](#proxy-patterns)                                  |
-| Multisig checks                                        | [Gnosis Safe](#gnosis-safe)                                        |
-| Role/ACL checks                                        | [Access control](#access-control)                                  |
-| Unknown return values                                  | [REPLACEME discovery](#replaceme-discovery)                        |
-| Overloaded function (two ABI fragments with same name) | [Function overloads](#function-overloads)                          |
-| Seed config (`--generate`)                             | [Seed configs](#seed-configs)                                      |
-| ABI not found / rate-limit / revert reading            | [Troubleshooting](#troubleshooting)                                |
+| Task                                                    | Go to                                                              |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| New config from scratch                                 | [Top-level structure](#top-level-structure), [Workflow](#workflow) |
+| Contract with a proxy                                   | [Proxy patterns](#proxy-patterns)                                  |
+| Multisig checks                                         | [Gnosis Safe](#gnosis-safe)                                        |
+| Role/ACL checks                                         | [Access control](#access-control)                                  |
+| Unknown return values                                   | [REPLACEME discovery](#replaceme-discovery)                        |
+| Overloaded function (two ABI fragments with same name)  | [Function overloads](#function-overloads)                          |
+| Seed config (`--generate`)                              | [Seed configs](#seed-configs)                                      |
+| ABI not found / rate-limit / revert reading             | [Troubleshooting](#troubleshooting)                                |
+| Deployment verification / audit (pre-vote state, roles) | Read `references/verification-playbook.md`                         |
 
 ## Top-level structure
 
@@ -46,11 +47,11 @@ roles: # bytes32 role hashes, often many (one per domain)
 eoa: # named EOAs (deployer, signer addresses); useful for "deployer renounced" checks
   - &deployer "0x..."
 
-l1: # per-chain section — key matches deployed.* key
+l1: # per-chain section — literal key name, not the chain's own name
   rpcUrl: L1_MAINNET_RPC_URL # env-var name, or inline URL
   explorerHostname: api.etherscan.io/v2/api
   explorerTokenEnv: ETHERSCAN_TOKEN
-  chainId: 1
+  chainId: 1 # number or string
   contracts:
     contractName:
       # ...
@@ -60,7 +61,9 @@ l2: # present when deployed.l2 exists
   # ...
 ```
 
-`parameters`, `deployed`, `misc`, `roles`, `eoa` are anchor-only sections — they define YAML anchors (`&name`) that later sections reference via `*name`. Only `<chain-key>` sections with `contracts:` produce on-chain calls.
+`parameters`, `deployed`, `misc`, `roles`, `eoa` are anchor-only sections — they define YAML anchors (`&name`) that later sections reference via `*name`. `deployed-aux`, `tvl`, `delays`, `signers`, `selectors`, `validators` are optional anchor-only sections too, same shape as `misc`. Only `<chain-key>` sections with `contracts:` produce on-chain calls.
+
+`deployed` and the per-chain sections accept exactly two keys: `l1` (required) and `l2` (optional) — fixed schema literals, not placeholders for the actual network's name. A config for a single L2 chain still uses `l1:`, never the chain's own name.
 
 ## Contract patterns
 
@@ -77,7 +80,7 @@ contractName:
 
 ### Proxy patterns
 
-**Transparent Upgradeable Proxy** (OpenZeppelin classic). `proxyChecks: {}` because the admin/impl live in EIP-1967 slots, which you verify via `storage:`:
+**Transparent Upgradeable Proxy**. `proxyChecks: {}` because the admin/impl live in EIP-1967 slots, which you verify via `storage:`:
 
 ```yaml
 contractName:
@@ -110,7 +113,7 @@ contractName:
   proxyName: OssifiableProxy
   implementation: *implAddress
   proxyChecks:
-    proxy__getAdmin: *aragonAgent
+    proxy__getAdmin: *proxyAdminAddress
     proxy__getImplementation: *implAddress
     proxy__getIsOssified: false
   checks:
@@ -119,20 +122,20 @@ contractName:
     someFunction: *ZERO_ADDRESS
 ```
 
-**AppProxyUpgradeable** (Aragon apps) has its own shape:
+**AppProxyUpgradeable** has its own shape:
 
 ```yaml
 contractName:
-  name: Lido
-  address: *lido
+  name: ContractName
+  address: *contractAddress
   proxyName: AppProxyUpgradeable
-  implementation: *lidoImplAddress
+  implementation: *implAddress
   proxyChecks:
     proxyType: *PROXY_TYPE_APP_PROXY_UPGRADEABLE
     isDepositable: false
-    implementation: *lidoImplAddress
-    appId: *LIDO_APP_ID
-    kernel: *aragonKernel
+    implementation: *implAddress
+    appId: *APP_ID
+    kernel: *kernelAddress
 ```
 
 ### ProxyAdmin
@@ -155,10 +158,19 @@ cast call $ADDRESS "VERSION()(string)" --rpc-url $RPC
 # Safe → returns "1.4.1"; EOA or non-Safe → reverts
 ```
 
+A Safe is a SafeProxy delegating to a singleton — model it as a proxy. `name:` is the singleton contract (its ABI carries all view functions); SafeProxy exposes no view functions (`masterCopy()` is a fallback trick absent from the ABI), so `proxyChecks: {}` and the linkage is verified via slot 0:
+
 ```yaml
 multisigName:
-  name: GnosisSafe
+  name: Safe # GnosisSafe for pre-1.3.0 deployments
   address: *multisigAddress
+  proxyName: SafeProxy
+  implementation: *safeSingleton # canonical singleton for that version
+  proxyChecks: {}
+  storage:
+    - slot: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      expected: *safeSingleton
+      label: singleton
   checks:
     VERSION: "1.4.1"
     getThreshold: *THRESHOLD_VALUE
@@ -260,9 +272,9 @@ When the ABI has two fragments with the same name, state-mate needs disambiguati
 ```yaml
 checks:
   domainSeparatorV4:
-    - args: [*lido]
+    - args: [*contractAddress]
       signature: "domainSeparatorV4(address)"
-      result: *LIDO_DOMAIN_SEPARATOR
+      result: *DOMAIN_SEPARATOR
 ```
 
 ## Access control
@@ -346,14 +358,14 @@ cast call $CONTRACT "hasRole(bytes32,address)(bool)" $ROLE $ADDRESS --rpc-url $R
 
 ## Seed configs
 
-A seed config is a thin starter file named `*.seed.yml`. It contains only address-book and chain-explorer sections (`deployed:`, `l1:` / `l2:` with `rpcUrl` / `explorerHostname`, optional `eoa:` / `roles:` / `misc:`) — **no `contracts:` block**. `yarn start <seed> --generate` walks every anchor under `deployed:`, resolves the ABI for each address, and writes a sibling `*.seed.generated.yml` with a populated `contracts:` block where each function value is `REPLACEME` (and, for proxies, a commented-out `implementationChecks` stub).
+A seed config is a thin starter file named `*.seed.yaml`. It contains only address-book and chain-explorer sections (`deployed:`, `l1:` / `l2:` with `rpcUrl` / `explorerHostname`, optional `eoa:` / `roles:` / `misc:`) — **no `contracts:` block**. `yarn start <seed> --generate` walks every anchor under `deployed:`, resolves the ABI for each address, and writes a sibling `*.seed.generated.yaml` with a populated `contracts:` block where each function value is `REPLACEME` (and, for proxies, a commented-out `implementationChecks` stub).
 
 `--generate` on its own does not fetch ABIs — it only uses ABIs already on disk. Combine with `--update-abi-missing` on first run.
 
 ```bash
-yarn start configs/proto/mainnet.seed.yml --generate --update-abi-missing
-# Review *.seed.generated.yml, replace REPLACEME with real expectations, then:
-yarn start configs/proto/mainnet.seed.generated.yml
+yarn start configs/proto/mainnet.seed.yaml --generate --update-abi-missing
+# Review *.seed.generated.yaml, replace REPLACEME with real expectations, then:
+yarn start configs/proto/mainnet.seed.generated.yaml
 ```
 
 ## Workflow
@@ -389,7 +401,7 @@ yarn start config.yml -o l1/contractName                  # specific contract (g
 yarn start config.yml -o l1/contractName/checks/funcName  # single function
 yarn start config.yml --update-abi-missing                # download only missing ABIs (preferred)
 yarn start config.yml --update-abi                        # overwrite all ABIs (rarely needed)
-yarn start config.seed.yml --generate                     # expand seed → *.seed.generated.yml
+yarn start config.seed.yaml --generate                    # expand seed → *.seed.generated.yaml
 ```
 
 ## Best practices
@@ -413,6 +425,10 @@ yarn start config.seed.yml --generate                     # expand seed → *.se
 
 - The contract is standard AccessControl, not Enumerable — switch to `ozNonEnumerableAcl:` or raw `hasRole` checks.
 - Or the contract doesn't expose role management at all — skip the role block.
+
+### `Non-covered functions: ...`
+
+- `checks:` must list every view function of the ABI (unknown ones as `null`). `implementationChecks:` doesn't have this requirement: it auto-fills unlisted functions as skipped.
 
 ### `missing revert data` with `data=null`
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,5 @@
 name: Setup state-mate
-description: Enable Corepack, install Node 20 (yarn cache), run yarn install --immutable.
+description: Enable Corepack, install Node 22 (yarn cache), run yarn install --immutable.
 
 runs:
   using: composite
@@ -7,7 +7,7 @@ runs:
     # Corepack must come before actions/setup-node: when `cache: yarn` is
     # set, setup-node invokes yarn to locate the cache folder. Without the
     # shim, it falls back to the runner's system yarn (v1), which refuses
-    # to run a project with `packageManager: yarn@4.3.1` in package.json.
+    # to run a project with `packageManager: yarn@4.x` in package.json.
     - name: Enable Corepack
       run: corepack enable
       shell: bash
@@ -15,7 +15,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: "20"
+        node-version: "22"
         cache: "yarn"
 
     - name: Install dependencies

--- a/.skills/state-mate/SKILL.md
+++ b/.skills/state-mate/SKILL.md
@@ -48,7 +48,7 @@ l1:
 
 ```yaml
 contractName:
-  name: ContractName  # Must match ABI filename
+  name: ContractName # Must match ABI filename
   address: *contractAddress
   checks:
     functionName: expectedValue
@@ -63,7 +63,7 @@ contractName:
   address: *contractAddress
   proxyName: TransparentUpgradeableProxy
   implementation: *implementationAddress
-  proxyChecks: {}  # Usually empty for transparent proxies
+  proxyChecks: {} # Usually empty for transparent proxies
   storage:
     - slot: *EIP1967_ADMIN_SLOT
       expected: *proxyAdminAddress
@@ -76,7 +76,7 @@ contractName:
     someFunction: expectedValue
   implementationChecks:
     # Checks run directly against implementation (uninitialized state)
-    someFunction: *ZERO_ADDRESS  # Usually zero/empty values
+    someFunction: *ZERO_ADDRESS # Usually zero/empty values
 ```
 
 ### 3. ProxyAdmin Contract
@@ -131,7 +131,7 @@ checks:
     - args: [0]
       result: *firstItem
     - args: [1]
-      mustRevert: true  # Index out of bounds
+      mustRevert: true # Index out of bounds
 ```
 
 ### Tuple/Array Return Values
@@ -154,7 +154,7 @@ checks:
 ozAcl:
   *DEFAULT_ADMIN_ROLE : [*adminAddress]
   *SOME_ROLE : [*holder1, *holder2]
-  *UNUSED_ROLE : []  # Verify role has 0 members
+  *UNUSED_ROLE : [] # Verify role has 0 members
 ```
 
 ### Standard AccessControl (hasRole checks)
@@ -287,7 +287,7 @@ For comprehensive role verification:
 ```yaml
 deployed:
   l1:
-    - &deployer "0x..."  # Add deployer address for verification
+    - &deployer "0x..." # Add deployer address for verification
 
 ozAcl:
   # Roles with members

--- a/.skills/state-mate/references/agent.md
+++ b/.skills/state-mate/references/agent.md
@@ -106,7 +106,7 @@ contractName:
 ```yaml
 ozAcl:
   *ROLE_WITH_MEMBERS : [*holder1, *holder2]
-  *ROLE_WITHOUT_MEMBERS : []  # Verify 0 members
+  *ROLE_WITHOUT_MEMBERS : [] # Verify 0 members
 ```
 
 ### hasRole (Standard AccessControl)

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
+enableScripts: true
+
 nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,1 @@
-enableScripts: true
-
 nodeLinker: node-modules

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,13 +41,9 @@ export default [
       // unicorn v69 migration: opinionated new rules that conflict with the codebase style
       "unicorn/max-nested-calls": "off", // chalk calls inside template literals
       "unicorn/no-top-level-assignment-in-function": "off", // g_* module-level state is deliberate
-      "unicorn/no-break-in-nested-loop": "off",
-      "unicorn/no-declarations-before-early-exit": "off",
+      "unicorn/no-break-in-nested-loop": "off", // flags mandatory breaks of a switch inside a loop
       "unicorn/no-top-level-side-effects": "off", // CLI entrypoints
-      "unicorn/consistent-class-member-order": "off",
-      "unicorn/consistent-boolean-name": "off",
-      "unicorn/prefer-await": "off", // CommonJS entrypoints cannot top-level await; main().catch() is the pattern
-      "unicorn/prefer-number-coercion": "off", // Number("") === 0 vs parseInt("") === NaN: keep strict parsing
+      "unicorn/consistent-boolean-name": "off", // its is*-prefix autofix produces worse names (reverted in review)
       "unicorn/consistent-function-scoping": "off",
       "@typescript-eslint/no-explicit-any": ["warn"],
       "@typescript-eslint/no-unused-vars": ["warn"],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,14 @@ export default [
 
   includeIgnoreFile(gitignorePath),
   {
+    // CommonJS entrypoints: no top-level await, main().catch() is the pattern
+    files: ["src/state-mate.ts", "src/gen-schemas.ts", "src/consolidate-abis.ts", "src/test-util/app.ts"],
+    rules: {
+      "unicorn/prefer-top-level-await": "off",
+      "unicorn/prefer-await": "off",
+    },
+  },
+  {
     languageOptions: {
       parser: tsParser,
       ecmaVersion: 2022,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,16 @@ export default [
       "unicorn/prefer-module": "off",
       "unicorn/no-process-exit": "off",
       "unicorn/no-object-as-default-parameter": "off",
+      // unicorn v69 migration: opinionated new rules that conflict with the codebase style
+      "unicorn/max-nested-calls": "off", // chalk calls inside template literals
+      "unicorn/no-top-level-assignment-in-function": "off", // g_* module-level state is deliberate
+      "unicorn/no-break-in-nested-loop": "off",
+      "unicorn/no-declarations-before-early-exit": "off",
+      "unicorn/no-top-level-side-effects": "off", // CLI entrypoints
+      "unicorn/consistent-class-member-order": "off",
+      "unicorn/consistent-boolean-name": "off",
+      "unicorn/prefer-await": "off", // CommonJS entrypoints cannot top-level await; main().catch() is the pattern
+      "unicorn/prefer-number-coercion": "off", // Number("") === 0 vs parseInt("") === NaN: keep strict parsing
       "unicorn/consistent-function-scoping": "off",
       "@typescript-eslint/no-explicit-any": ["warn"],
       "@typescript-eslint/no-unused-vars": ["warn"],

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "state-checker.ts",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
-  "packageManager": "yarn@4.3.1",
+  "packageManager": "yarn@4.17.0",
   "scripts": {
     "build": "tsc",
     "start": "ts-node -r tsconfig-paths/register src/state-mate.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "node": ">=22"
   },
   "packageManager": "yarn@4.17.0",
+  "dependenciesMeta": {
+    "unrs-resolver": {
+      "built": true
+    }
+  },
   "scripts": {
     "build": "tsc",
     "start": "ts-node -r tsconfig-paths/register src/state-mate.ts",

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -210,7 +210,7 @@ export function loadAbiFromFile(
       logErrorAndExit(
         `Error finding ABI file for contract
         ${contractName} in ${g_Arguments.abiDirPath}: ${printError(error)}\n\n` +
-          chalk.yellow.bold(`Try running with the '--update-abi' option to download the unnecessary ABI`),
+          chalk.yellow.bold(`Try running with the '--update-abi' option to download the missing ABI`),
       );
     }
     return loadAbiFromAbiPath(abiPath);

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -50,24 +50,24 @@ function determineAbiMode(): AbiMode {
   }
 
   const consolidatedFile = getConsolidatedAbiPathToUse();
-  const consolidatedExists = consolidatedFile !== null;
+  const isConsolidatedExists = consolidatedFile !== null;
 
-  let individualFilesExist = false;
+  let isIndividualFilesExist = false;
   if (fs.existsSync(g_Arguments.abiDirPath)) {
     const files = fs.readdirSync(g_Arguments.abiDirPath);
-    individualFilesExist = files.some((file) => file.endsWith(".json") && file !== CONSOLIDATED_ABI_FILENAME);
+    isIndividualFilesExist = files.some((file) => file.endsWith(".json") && file !== CONSOLIDATED_ABI_FILENAME);
   }
 
-  if (consolidatedExists && individualFilesExist) {
+  if (isConsolidatedExists && isIndividualFilesExist) {
     logErrorAndExit(
       `Cannot use both consolidated ${chalk.yellow(CONSOLIDATED_ABI_FILENAME)} and individual ABI files.\n` +
         `Please remove one format from ${chalk.magenta(g_Arguments.abiDirPath)}`,
     );
   }
 
-  if (consolidatedExists) {
+  if (isConsolidatedExists) {
     g_abiMode = "consolidated";
-  } else if (individualFilesExist) {
+  } else if (isIndividualFilesExist) {
     g_abiMode = "individual";
   } else {
     g_abiMode = "none";
@@ -200,7 +200,8 @@ export function loadAbiFromFile(
     }
 
     return abi;
-  } else if (mode === "individual") {
+  }
+  if (mode === "individual") {
     let abiPath;
     try {
       abiPath = _findAbiPath(contractName, address, { shouldThrow: true, allowAddressFallback });
@@ -213,10 +214,9 @@ export function loadAbiFromFile(
       logErrorAndExit(message);
     }
     return loadAbiFromAbiPath(abiPath);
-  } else {
-    if (failSilently) return null;
-    logErrorAndExit(`No ABI files found in ${chalk.magenta(g_Arguments.abiDirPath)}`);
   }
+  if (failSilently) return null;
+  logErrorAndExit(`No ABI files found in ${chalk.magenta(g_Arguments.abiDirPath)}`);
 }
 
 export function abiExistsForAddress(address: string): boolean {
@@ -226,7 +226,8 @@ export function abiExistsForAddress(address: string): boolean {
   if (mode === "consolidated") {
     const abis = loadConsolidatedAbis();
     return findAbiKeysByAddress(Object.keys(abis), address).length > 0;
-  } else if (mode === "individual") {
+  }
+  if (mode === "individual") {
     if (!fs.existsSync(g_Arguments.abiDirPath)) return false;
     try {
       const files = fs.readdirSync(g_Arguments.abiDirPath);
@@ -314,22 +315,22 @@ async function _checkAbi(contractName: string, address: string, abiFromExplorer:
   const mode = determineAbiMode();
 
   let savedAbi: Abi | null = null;
-  let abiExists = false;
+  let isAbiExists = false;
 
   if (mode === "consolidated") {
     const abis = loadConsolidatedAbis();
     const key = getAbiKey(contractName, address);
     savedAbi = abis[key] || abis[contractName] || null;
-    abiExists = savedAbi !== null;
+    isAbiExists = savedAbi !== null;
   } else if (mode === "individual") {
     const abiExistedPath = _findAbiPath(contractName, address, { shouldThrow: false });
     if (abiExistedPath) {
       savedAbi = loadAbiFromAbiPath(abiExistedPath);
-      abiExists = true;
+      isAbiExists = true;
     }
   }
 
-  if (abiExists && savedAbi) {
+  if (isAbiExists && savedAbi) {
     if (g_Arguments.updateAbiMissingOnly) {
       logHandler.success("Skipped (exists)");
       return;
@@ -346,7 +347,7 @@ async function _checkAbi(contractName: string, address: string, abiFromExplorer:
       : _findAbiPath(contractName, address, { shouldThrow: false }) || _defaultAbiFilePath(contractName, address);
 
   _saveAbi(abiFileNameToSave, abiFromExplorer);
-  logHandler.success(abiExists ? "Overwritten" : "Saved");
+  logHandler.success(isAbiExists ? "Overwritten" : "Saved");
 }
 
 function _saveAbi(abiFileName: string, abiFromExplorer: Abi) {
@@ -496,7 +497,7 @@ function toLowerCaseAddress(fileName: string): string {
   if (!match) return fileName;
 
   const address = match[0];
-  return fileName.replace(address, address.toLowerCase());
+  return fileName.replace(address, () => address.toLowerCase());
 }
 
 function normalizeConsolidatedAbiKeys(
@@ -504,20 +505,20 @@ function normalizeConsolidatedAbiKeys(
   options: { onRename?: (from: string, to: string) => void } = {},
 ): { normalized: Record<string, Abi>; renamed: boolean } {
   const normalized: Record<string, Abi> = {};
-  let renamed = false;
+  let isRenamed = false;
 
   for (const [key, abi] of Object.entries(abis)) {
     const normalizedKey = toLowerCaseAddress(key);
 
     if (normalizedKey !== key) {
-      renamed = true;
+      isRenamed = true;
       options.onRename?.(key, normalizedKey);
     }
 
     normalized[normalizedKey] = abi;
   }
 
-  return { normalized: normalized, renamed };
+  return { normalized: normalized, renamed: isRenamed };
 }
 
 function _renameAbiIfNeed(fileName: string): void {

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -417,25 +417,26 @@ export function resetAbiModeCache(): void {
   g_abiMode = null;
 }
 
+type FindAbiOptions = { shouldThrow?: boolean; allowAddressFallback?: boolean };
+
 function _findAbiPath(
   contractName: string,
   contractAddress: string,
-  shouldThrow: { shouldThrow: true; allowAddressFallback?: boolean },
+  options: FindAbiOptions & { shouldThrow: true },
 ): string;
 
 function _findAbiPath(
   contractName: string,
   contractAddress: string,
-  shouldThrow?: { shouldThrow: false; allowAddressFallback?: boolean },
+  options?: FindAbiOptions & { shouldThrow?: false },
 ): string | null;
 
-function _findAbiPath(
-  contractName: string,
-  contractAddress: string,
-  { shouldThrow, allowAddressFallback = true }: { shouldThrow?: boolean; allowAddressFallback?: boolean } = {
-    shouldThrow: false,
-  },
-): string | null {
+function _findAbiPath(contractName: string, contractAddress: string, options: FindAbiOptions = {}): string | null {
+  // allowAddressFallback defaults to false: matching by address alone can return a file named
+  // after another contract (e.g. the proxy's own ABI), which must never be picked implicitly,
+  // and never overwritten when saving. Readers opt in explicitly.
+  const { shouldThrow = false, allowAddressFallback = false } = options;
+
   if (!contractName || !g_Arguments.abiDirPath) return null;
 
   // prettier-ignore

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -437,7 +437,12 @@ function _findAbiPath(contractName: string, contractAddress: string, options: Fi
   // and never overwritten when saving. Readers opt in explicitly.
   const { shouldThrow = false, allowAddressFallback = false } = options;
 
-  if (!contractName || !g_Arguments.abiDirPath) return null;
+  if (!contractName || !g_Arguments.abiDirPath) {
+    if (shouldThrow) {
+      throw new Error(`ABI lookup failed: ${contractName ? "ABI directory path is not set" : "empty contract name"}`);
+    }
+    return null;
+  }
 
   // prettier-ignore
   const abiVariantsName = [

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -50,24 +50,24 @@ function determineAbiMode(): AbiMode {
   }
 
   const consolidatedFile = getConsolidatedAbiPathToUse();
-  const isConsolidatedExists = consolidatedFile !== null;
+  const consolidatedExists = consolidatedFile !== null;
 
-  let isIndividualFilesExist = false;
+  let individualFilesExist = false;
   if (fs.existsSync(g_Arguments.abiDirPath)) {
     const files = fs.readdirSync(g_Arguments.abiDirPath);
-    isIndividualFilesExist = files.some((file) => file.endsWith(".json") && file !== CONSOLIDATED_ABI_FILENAME);
+    individualFilesExist = files.some((file) => file.endsWith(".json") && file !== CONSOLIDATED_ABI_FILENAME);
   }
 
-  if (isConsolidatedExists && isIndividualFilesExist) {
+  if (consolidatedExists && individualFilesExist) {
     logErrorAndExit(
       `Cannot use both consolidated ${chalk.yellow(CONSOLIDATED_ABI_FILENAME)} and individual ABI files.\n` +
         `Please remove one format from ${chalk.magenta(g_Arguments.abiDirPath)}`,
     );
   }
 
-  if (isConsolidatedExists) {
+  if (consolidatedExists) {
     g_abiMode = "consolidated";
-  } else if (isIndividualFilesExist) {
+  } else if (individualFilesExist) {
     g_abiMode = "individual";
   } else {
     g_abiMode = "none";

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -32,12 +32,13 @@ function getConsolidatedAbiPathGz(): string {
 
 function getConsolidatedAbiPathToUse(): { path: string; isCompressed: boolean } | null {
   const gzPath = getConsolidatedAbiPathGz();
-  const jsonPath = getConsolidatedAbiPath();
 
   // Prefer compressed version if it exists
   if (fs.existsSync(gzPath)) {
     return { path: gzPath, isCompressed: true };
   }
+
+  const jsonPath = getConsolidatedAbiPath();
   if (fs.existsSync(jsonPath)) {
     return { path: jsonPath, isCompressed: false };
   }
@@ -179,24 +180,23 @@ export function loadAbiFromFile(
       if (addressMatches.length === 1) {
         abi = abis[addressMatches[0]];
       } else if (addressMatches.length > 1) {
-        const message =
-          `ABI lookup for ${chalk.yellow(key)} is ambiguous.\n` +
-          `The following consolidated ABI keys match address ${chalk.yellow(address)}:\n` +
-          `${addressMatches.join(", ")}\n\n` +
-          `Please align the contract ${chalk.yellow("name")} in YAML or keep a unique ABI key per address.`;
-
         if (failSilently) return null;
-        logErrorAndExit(message);
+        logErrorAndExit(
+          `ABI lookup for ${chalk.yellow(key)} is ambiguous.\n` +
+            `The following consolidated ABI keys match address ${chalk.yellow(address)}:\n` +
+            `${addressMatches.join(", ")}\n\n` +
+            `Please align the contract ${chalk.yellow("name")} in YAML or keep a unique ABI key per address.`,
+        );
       }
     }
 
     if (!abi) {
-      const message =
-        `ABI not found in consolidated file for ${chalk.yellow(key)}\n` +
-        `Available keys: ${formatConsolidatedKeys(allKeys)}\n\n` +
-        chalk.yellow.bold(`Try running with the '--update-abi' option to download the ABI`);
       if (failSilently) return null;
-      logErrorAndExit(message);
+      logErrorAndExit(
+        `ABI not found in consolidated file for ${chalk.yellow(key)}\n` +
+          `Available keys: ${formatConsolidatedKeys(allKeys)}\n\n` +
+          chalk.yellow.bold(`Try running with the '--update-abi' option to download the ABI`),
+      );
     }
 
     return abi;
@@ -206,12 +206,12 @@ export function loadAbiFromFile(
     try {
       abiPath = _findAbiPath(contractName, address, { shouldThrow: true, allowAddressFallback });
     } catch (error) {
-      const message =
+      if (failSilently) return null;
+      logErrorAndExit(
         `Error finding ABI file for contract
         ${contractName} in ${g_Arguments.abiDirPath}: ${printError(error)}\n\n` +
-        chalk.yellow.bold(`Try running with the '--update-abi' option to download the unnecessary ABI`);
-      if (failSilently) return null;
-      logErrorAndExit(message);
+          chalk.yellow.bold(`Try running with the '--update-abi' option to download the unnecessary ABI`),
+      );
     }
     return loadAbiFromAbiPath(abiPath);
   }

--- a/src/boilerplate-generator.ts
+++ b/src/boilerplate-generator.ts
@@ -106,7 +106,7 @@ export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument
 }
 
 function writeGeneratedYaml(filePath: string, fileContent: string) {
-  const generatedDocument = addSchemaIntoYaml(filePath, fileContent.toString());
+  const generatedDocument = addSchemaIntoYaml(filePath, fileContent);
   try {
     fs.writeFileSync(filePath, generatedDocument);
     log(`Generated state config: ${chalk.bold(filePath)}`);
@@ -120,7 +120,7 @@ function addSchemaIntoYaml(filePath: string, fileContent: string): string {
   const relativePathToMainSchema = path.join(path.relative(path.dirname(filePath), schemaPath), MAIN_SCHEMA_NAME);
   const regex = /\$schema=.*/;
   fileContent = regex.test(fileContent)
-    ? fileContent.replace(regex, `$schema=${relativePathToMainSchema}`)
+    ? fileContent.replace(regex, () => `$schema=${relativePathToMainSchema}`)
     : `# yaml-language-server: $schema=${relativePathToMainSchema}\n` + fileContent;
 
   return fileContent;

--- a/src/boilerplate-generator.ts
+++ b/src/boilerplate-generator.ts
@@ -16,7 +16,7 @@ import { ContractEntry, EntireDocument, ExplorerSectionTB, isTypeOfTB, NetworkSe
 import { MethodCallResults, Abi } from "./types";
 
 const REPLACE_ME_PLACEHOLDER = "REPLACEME";
-const YML = "yml";
+const YAML_EXT = "yaml";
 const MAIN_SCHEMA_NAME = "main-schema.json";
 
 export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument: SeedDocument) {
@@ -100,7 +100,7 @@ export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument
 
   const generatedFilePath = path.join(
     path.dirname(seedConfigPath),
-    `${path.basename(seedConfigPath, "." + YML)}.generated.${YML}`,
+    `${path.basename(seedConfigPath, "." + YAML_EXT)}.generated.${YAML_EXT}`,
   );
   writeGeneratedYaml(generatedFilePath, document.toString());
 }

--- a/src/boilerplate-generator.ts
+++ b/src/boilerplate-generator.ts
@@ -16,7 +16,6 @@ import { ContractEntry, EntireDocument, ExplorerSectionTB, isTypeOfTB, NetworkSe
 import { MethodCallResults, Abi } from "./types";
 
 const REPLACE_ME_PLACEHOLDER = "REPLACEME";
-const YAML_EXT = "yaml";
 const MAIN_SCHEMA_NAME = "main-schema.json";
 
 export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument: SeedDocument) {
@@ -98,9 +97,10 @@ export async function doGenerateBoilerplate(seedConfigPath: string, jsonDocument
     sectionNode.addIn([EntryField.contracts], new YAML.Pair(context.deployedNode.anchor, contractEntry));
   });
 
+  const extension = path.extname(seedConfigPath);
   const generatedFilePath = path.join(
     path.dirname(seedConfigPath),
-    `${path.basename(seedConfigPath, "." + YAML_EXT)}.generated.${YAML_EXT}`,
+    `${path.basename(seedConfigPath, extension)}.generated${extension}`,
   );
   writeGeneratedYaml(generatedFilePath, document.toString());
 }

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -12,7 +12,7 @@ type CheckOnlyOptionType = null | {
   method?: string;
 };
 
-export function parseCmdLineArguments() {
+export function parseCommandLineArguments() {
   program
     .argument("<config-path>", "path to .yaml state config file")
     .allowExcessArguments(false)

--- a/src/common.ts
+++ b/src/common.ts
@@ -53,10 +53,5 @@ export function getNonMutables(abi: Abi): AbiArgumentsLength {
 }
 
 function isUrl(maybeUrl: string) {
-  try {
-    new URL(maybeUrl);
-    return true;
-  } catch {
-    return false;
-  }
+  return URL.canParse(maybeUrl);
 }

--- a/src/consolidate-abis.ts
+++ b/src/consolidate-abis.ts
@@ -57,7 +57,7 @@ function readAbiFiles(abiDirectoryPath: string): ConsolidatedAbis {
       }
 
       // Warn about duplicate keys
-      if (consolidatedAbis[key]) {
+      if (Object.hasOwn(consolidatedAbis, key)) {
         console.warn(`⚠ Duplicate key detected: ${key} (overwriting previous entry)`);
       }
 

--- a/src/explorer-provider.ts
+++ b/src/explorer-provider.ts
@@ -140,7 +140,7 @@ export async function loadContractInfo(
 
     return contractInfo;
   } catch {
-    const logHandler = new LogCommand(`ABI ${chalk.magenta(`${address}`)}`);
+    const logHandler = new LogCommand(`ABI ${chalk.magenta(address)}`);
     logHandler.failure(
       `Failed to parse contract source code (${chalk.yellow(sourcesResponse.result[0].ABI)}). Maybe EOF?`,
     );
@@ -183,7 +183,7 @@ function _getExplorerApiUrl(
   }
 
   if (explorerKey) {
-    url = `${url}&apikey=${explorerKey}`;
+    url += `&apikey=${explorerKey}`;
   }
 
   return url;

--- a/src/gen-schemas.ts
+++ b/src/gen-schemas.ts
@@ -32,5 +32,5 @@ async function main() {
   generateBothSchemas();
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
+// eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/prefer-await -- CommonJS entrypoint
 main().catch((error) => console.error(error));

--- a/src/gen-schemas.ts
+++ b/src/gen-schemas.ts
@@ -32,5 +32,4 @@ async function main() {
   generateBothSchemas();
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/prefer-await -- CommonJS entrypoint
 main().catch((error) => console.error(error));

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,7 +10,7 @@ export const WARNING_MARK = chalk.yellow("⚠");
 const TREE_BRANCH = chalk.gray("├──");
 const TREE_LAST = chalk.gray("└──");
 const TREE_PIPE = chalk.gray("│  ");
-const TREE_SPACE = "   ";
+const TREE_SPACE = " ".repeat(3);
 
 // Track current item prefix for tree structure
 let itemPrefix = "";
@@ -91,7 +91,7 @@ export function log(argument: unknown) {
 export function logReplaceLine(argument: unknown) {
   process.stdout.clearLine(0);
   process.stdout.cursorTo(0);
-  process.stdout.write(`${String(argument)}`);
+  process.stdout.write(String(argument));
 }
 
 export function logError(argument: unknown) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,6 +27,11 @@ export class LogCommand {
     this.initialPrint();
   }
 
+  private initialPrint(): void {
+    const prefix = getItemPrefix();
+    process.stdout.write(`${prefix}  ${this.description}: ...`);
+  }
+
   public printResult(statusSymbol: string, result: string): void {
     readline.cursorTo(process.stdout, 0);
     readline.clearLine(process.stdout, 0);
@@ -44,11 +49,6 @@ export class LogCommand {
 
   public warning(result: string): void {
     this.printResult(WARNING_MARK, result);
-  }
-
-  private initialPrint(): void {
-    const prefix = getItemPrefix();
-    process.stdout.write(`${prefix}  ${this.description}: ...`);
   }
 }
 

--- a/src/section-validators/base.ts
+++ b/src/section-validators/base.ts
@@ -86,7 +86,7 @@ export function needCheck(level: CheckLevel, name: string) {
     return true;
   }
   const checkOnTheLevel = g_Arguments.checkOnly[level];
-  return checkOnTheLevel === null || checkOnTheLevel === undefined || name === checkOnTheLevel;
+  return checkOnTheLevel == null || name === checkOnTheLevel;
 }
 
 export abstract class SectionValidatorBase {
@@ -184,7 +184,7 @@ export abstract class SectionValidatorBase {
 }
 
 function _stringify(value: unknown) {
-  return value instanceof Object ? JSON.stringify(value) : `${String(value)}`;
+  return value instanceof Object ? JSON.stringify(value) : String(value);
 }
 
 function _assertEqual(actual: unknown, expected: ViewResult, errorMessage?: string) {
@@ -242,10 +242,12 @@ function toBigIntIfPossible(value: unknown): bigint | unknown {
 }
 
 function _equalOrThrow(actual: unknown, expected: unknown, errorMessage?: string) {
-  if (toBigIntIfPossible(actual) !== toBigIntIfPossible(expected)) {
-    if (!errorMessage) {
-      errorMessage = `Expected "${_stringify(expected)}" to equal actual "${_stringify(actual)}"`;
-    }
-    throw new AssertionError(errorMessage);
+  if (toBigIntIfPossible(actual) === toBigIntIfPossible(expected)) {
+    return;
   }
+
+  if (!errorMessage) {
+    errorMessage = `Expected "${_stringify(expected)}" to equal actual "${_stringify(actual)}"`;
+  }
+  throw new AssertionError(errorMessage);
 }

--- a/src/section-validators/checks.ts
+++ b/src/section-validators/checks.ts
@@ -22,6 +22,24 @@ export class ChecksSectionValidator extends SectionValidatorBase {
     super(provider, sectionName);
   }
 
+  private async _validateSubsection(contract: Contract, method: string, checkEntryValue: ChecksEntryValue) {
+    if (isTypeOfTB(checkEntryValue, ArrayOfStaticCallCheckTB)) {
+      if (checkEntryValue.length === 0) {
+        await this._checkViewFunction(contract, method, { result: [] });
+      } else {
+        for (const argumentsResult of checkEntryValue) {
+          await this._checkViewFunction(contract, method, argumentsResult);
+        }
+      }
+    } else if (isTypeOfTB(checkEntryValue, StaticCallCheckTB)) {
+      await this._checkViewFunction(contract, method, checkEntryValue);
+    } else if (isTypeOfTB(checkEntryValue, ViewResultTB)) {
+      await this._checkViewFunction(contract, method, { result: checkEntryValue });
+    } else {
+      logErrorAndExit(`Unknown check type: ${JSON.stringify(checkEntryValue)}`);
+    }
+  }
+
   override async validateSection(contractEntry: ContractEntry, contractAlias: string, basePath?: string) {
     void basePath; // Used for interface compatibility - header printed by contract.ts
     const { address, checks } = contractEntry;
@@ -60,23 +78,5 @@ export class ChecksSectionValidator extends SectionValidatorBase {
     }
 
     return loadAbiFromFile(name, address);
-  }
-
-  private async _validateSubsection(contract: Contract, method: string, checkEntryValue: ChecksEntryValue) {
-    if (isTypeOfTB(checkEntryValue, ArrayOfStaticCallCheckTB)) {
-      if (checkEntryValue.length === 0) {
-        await this._checkViewFunction(contract, method, { result: [] });
-      } else {
-        for (const argumentsResult of checkEntryValue) {
-          await this._checkViewFunction(contract, method, argumentsResult);
-        }
-      }
-    } else if (isTypeOfTB(checkEntryValue, StaticCallCheckTB)) {
-      await this._checkViewFunction(contract, method, checkEntryValue);
-    } else if (isTypeOfTB(checkEntryValue, ViewResultTB)) {
-      await this._checkViewFunction(contract, method, { result: checkEntryValue });
-    } else {
-      logErrorAndExit(`Unknown check type: ${JSON.stringify(checkEntryValue)}`);
-    }
   }
 }

--- a/src/section-validators/implementation-checks.ts
+++ b/src/section-validators/implementation-checks.ts
@@ -13,28 +13,30 @@ export class ImplementationChecksSectionValidator extends ChecksSectionValidator
   }
 
   override async validateSection(contractEntry: ContractEntry, contractAlias: string, basePath?: string) {
-    if (
+    if (!(
       isTypeOfTB(contractEntry, ProxyContractEntryTB) &&
       contractEntry.implementation &&
       contractEntry.implementationChecks
-    ) {
-      logHeader2(basePath ? `${basePath}/${this.sectionName}` : this.sectionName);
-      const { implementation, name, implementationChecks } = contractEntry;
-
-      const allNonMutable = getNonMutables(loadAbiFromFile(name, implementation));
-      const skippedChecks: RegularChecks = {};
-
-      for (const x of allNonMutable) {
-        skippedChecks[x.name] = null;
-      }
-      await super.validateSection(
-        {
-          checks: { ...skippedChecks, ...implementationChecks },
-          name: name,
-          address: implementation,
-        },
-        contractAlias,
-      );
+    )) {
+      return;
     }
+
+    logHeader2(basePath ? `${basePath}/${this.sectionName}` : this.sectionName);
+    const { implementation, name, implementationChecks } = contractEntry;
+
+    const allNonMutable = getNonMutables(loadAbiFromFile(name, implementation));
+    const skippedChecks: RegularChecks = {};
+
+    for (const x of allNonMutable) {
+      skippedChecks[x.name] = null;
+    }
+    await super.validateSection(
+      {
+        checks: { ...skippedChecks, ...implementationChecks },
+        name: name,
+        address: implementation,
+      },
+      contractAlias,
+    );
   }
 }

--- a/src/section-validators/oz-acl.ts
+++ b/src/section-validators/oz-acl.ts
@@ -18,55 +18,57 @@ export class OzAclSectionValidator extends SectionValidatorBase {
   }
 
   override async validateSection(contractEntry: ContractEntry, contractAlias: string, basePath?: string) {
-    if (contractEntry.ozAcl) {
-      const sectionPath = basePath ? `${basePath}/${this.sectionName}` : this.sectionName;
-      logHeader2(sectionPath);
+    if (!contractEntry.ozAcl) {
+      return;
+    }
 
-      const address = contractEntry.address;
-      const iface = new Interface(ACCESS_CONTROL_ABI);
-      const contract = new Contract(address, iface, this.provider);
+    const sectionPath = basePath ? `${basePath}/${this.sectionName}` : this.sectionName;
+    logHeader2(sectionPath);
 
-      const roles = Object.entries(contractEntry.ozAcl);
-      for (let index = 0; index < roles.length; index++) {
-        const [role, expectedAddrs] = roles[index];
-        const isLastRole = index === roles.length - 1;
-        logSubHeader(`Role: ${role}`, isLastRole);
+    const address = contractEntry.address;
+    const iface = new Interface(ACCESS_CONTROL_ABI);
+    const contract = new Contract(address, iface, this.provider);
 
-        // Get actual role member count
-        const actualCount = await contract.getRoleMemberCount(role);
-        const expectedCount = expectedAddrs.length;
+    const roles = Object.entries(contractEntry.ozAcl);
+    for (let index = 0; index < roles.length; index++) {
+      const [role, expectedAddrs] = roles[index];
+      const isLastRole = index === roles.length - 1;
+      logSubHeader(`Role: ${role}`, isLastRole);
 
-        // Check if counts match
-        const countCheck: StaticCallResult = {
-          signature: "getRoleMemberCount",
-          args: [role],
-          result: expectedCount,
-        };
-        await this._checkViewFunction(contract, "getRoleMemberCount", countCheck);
+      // Get actual role member count
+      const actualCount = await contract.getRoleMemberCount(role);
+      const expectedCount = expectedAddrs.length;
 
-        // If count doesn't match, enumerate actual members for debugging
-        if (Number(actualCount) !== expectedCount) {
-          logError(`Role member count mismatch. Actual members:`);
-          for (let index = 0; index < Number(actualCount); index++) {
-            try {
-              const member = await contract.getRoleMember(role, index);
-              logError(`  [${index}] ${member}`);
-            } catch {
-              // getRoleMember might not be available in all AccessControl implementations
-              break;
-            }
+      // Check if counts match
+      const countCheck: StaticCallResult = {
+        signature: "getRoleMemberCount",
+        args: [role],
+        result: expectedCount,
+      };
+      await this._checkViewFunction(contract, "getRoleMemberCount", countCheck);
+
+      // If count doesn't match, enumerate actual members for debugging
+      if (Number(actualCount) !== expectedCount) {
+        logError(`Role member count mismatch. Actual members:`);
+        for (let index = 0; index < Number(actualCount); index++) {
+          try {
+            const member = await contract.getRoleMember(role, index);
+            logError(`  [${index}] ${member}`);
+          } catch {
+            // getRoleMember might not be available in all AccessControl implementations
+            break;
           }
         }
+      }
 
-        // Check hasRole(role, addr) == true for each expected addr
-        for (const addr of expectedAddrs) {
-          const hasRoleCheck: StaticCallResult = {
-            signature: "hasRole",
-            args: [role, addr],
-            result: true,
-          };
-          await this._checkViewFunction(contract, "hasRole", hasRoleCheck);
-        }
+      // Check hasRole(role, addr) == true for each expected addr
+      for (const addr of expectedAddrs) {
+        const hasRoleCheck: StaticCallResult = {
+          signature: "hasRole",
+          args: [role, addr],
+          result: true,
+        };
+        await this._checkViewFunction(contract, "hasRole", hasRoleCheck);
       }
     }
   }

--- a/src/section-validators/oz-non-enumerable-acl.ts
+++ b/src/section-validators/oz-non-enumerable-acl.ts
@@ -14,6 +14,7 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
   constructor(provider: JsonRpcProvider) {
     super(provider, EntryField.ozNonEnumerableAcl);
   }
+
   override async validateSection(contractEntry: ContractEntry, contractAlias: string, basePath?: string) {
     void contractAlias; // Used for interface compatibility
     if (contractEntry.ozNonEnumerableAcl) {

--- a/src/section-validators/oz-non-enumerable-acl.ts
+++ b/src/section-validators/oz-non-enumerable-acl.ts
@@ -60,7 +60,8 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
 
     const rolesByHolders = new Map<string, Set<string>>();
     for (const role in contractEntry.ozNonEnumerableAcl) {
-      for (const holder of contractEntry.ozNonEnumerableAcl[role]) {
+      const holders = contractEntry.ozNonEnumerableAcl[role];
+      for (const holder of holders) {
         incChecks();
         if (!rolesByHolders.has(holder)) {
           rolesByHolders.set(holder, new Set<string>());
@@ -72,7 +73,7 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
         try {
           const isRoleOnHolder: unknown = await contract.getFunction("hasRole").staticCall(role, holder);
           assert.isTrue(isRoleOnHolder);
-          logHandle.success(`${isRoleOnHolder}`);
+          logHandle.success(String(isRoleOnHolder));
         } catch (error) {
           const errorMessage = `REVERTED with: ${(error as Error).message}`;
           logHandle.failure(errorMessage);
@@ -83,20 +84,22 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
 
     for (const [holder, rolesExpectedOnTheHolder] of rolesByHolders) {
       for (const role in contractEntry.ozNonEnumerableAcl) {
-        if (!rolesExpectedOnTheHolder.has(role)) {
-          incChecks();
-          const methodName = `.hasRole(${role}, ${holder})`;
-          const logHandle = new LogCommand(methodName);
-          setErrorContext({ method: methodName });
-          try {
-            const isRoleOnHolder: unknown = await contract.getFunction("hasRole").staticCall(role, holder);
-            assert.isFalse(isRoleOnHolder);
-            logHandle.success(`${isRoleOnHolder}`);
-          } catch (error) {
-            const errorMessage = `REVERTED with: ${(error as Error).message}`;
-            logHandle.failure(errorMessage);
-            incErrors(errorMessage);
-          }
+        if (rolesExpectedOnTheHolder.has(role)) {
+          continue;
+        }
+
+        incChecks();
+        const methodName = `.hasRole(${role}, ${holder})`;
+        const logHandle = new LogCommand(methodName);
+        setErrorContext({ method: methodName });
+        try {
+          const isRoleOnHolder: unknown = await contract.getFunction("hasRole").staticCall(role, holder);
+          assert.isFalse(isRoleOnHolder);
+          logHandle.success(String(isRoleOnHolder));
+        } catch (error) {
+          const errorMessage = `REVERTED with: ${(error as Error).message}`;
+          logHandle.failure(errorMessage);
+          incErrors(errorMessage);
         }
       }
     }

--- a/src/section-validators/proxy-check.ts
+++ b/src/section-validators/proxy-check.ts
@@ -13,22 +13,24 @@ export class ProxyCheckSectionValidator extends SectionValidatorBase {
     super(provider, EntryField.proxyChecks);
   }
   override async validateSection(contractEntry: ContractEntry, contractAlias: string, basePath?: string) {
-    if (isTypeOfTB(contractEntry, ProxyContractEntryTB) && contractEntry.proxyChecks) {
-      const { address, proxyName, proxyChecks } = contractEntry;
+    if (!(isTypeOfTB(contractEntry, ProxyContractEntryTB) && contractEntry.proxyChecks)) {
+      return;
+    }
 
-      // Skip if no checks defined
-      if (Object.keys(proxyChecks).length === 0) return;
+    const { address, proxyName, proxyChecks } = contractEntry;
 
-      logHeader2(basePath ? `${basePath}/${this.sectionName}` : this.sectionName);
+    // Skip if no checks defined
+    if (Object.keys(proxyChecks).length === 0) return;
 
-      const abi = loadAbiFromFile(proxyName, address);
-      this._reportNonCoveredNonMutableChecks(contractAlias, abi, Object.keys(proxyChecks));
+    logHeader2(basePath ? `${basePath}/${this.sectionName}` : this.sectionName);
 
-      const contract = loadContract(address, abi, this.provider);
-      for (const [method, checkEntryValue] of Object.entries(proxyChecks)) {
-        if (!needCheck(CheckLevel.method, method)) continue;
-        await this._validateSubsection(contract, method, checkEntryValue);
-      }
+    const abi = loadAbiFromFile(proxyName, address);
+    this._reportNonCoveredNonMutableChecks(contractAlias, abi, Object.keys(proxyChecks));
+
+    const contract = loadContract(address, abi, this.provider);
+    for (const [method, checkEntryValue] of Object.entries(proxyChecks)) {
+      if (!needCheck(CheckLevel.method, method)) continue;
+      await this._validateSubsection(contract, method, checkEntryValue);
     }
   }
 

--- a/src/section-validators/proxy-check.ts
+++ b/src/section-validators/proxy-check.ts
@@ -12,6 +12,15 @@ export class ProxyCheckSectionValidator extends SectionValidatorBase {
   constructor(provider: JsonRpcProvider) {
     super(provider, EntryField.proxyChecks);
   }
+
+  private async _validateSubsection(contract: Contract, method: string, checkEntryValue: ChecksEntryValue) {
+    if (isTypeOfTB(checkEntryValue, ViewResultTB)) {
+      await this._checkViewFunction(contract, method, { result: checkEntryValue });
+    } else {
+      logErrorAndExit(`Unknown check type: ${JSON.stringify(checkEntryValue)}`);
+    }
+  }
+
   override async validateSection(contractEntry: ContractEntry, contractAlias: string, basePath?: string) {
     if (!(isTypeOfTB(contractEntry, ProxyContractEntryTB) && contractEntry.proxyChecks)) {
       return;
@@ -31,14 +40,6 @@ export class ProxyCheckSectionValidator extends SectionValidatorBase {
     for (const [method, checkEntryValue] of Object.entries(proxyChecks)) {
       if (!needCheck(CheckLevel.method, method)) continue;
       await this._validateSubsection(contract, method, checkEntryValue);
-    }
-  }
-
-  private async _validateSubsection(contract: Contract, method: string, checkEntryValue: ChecksEntryValue) {
-    if (isTypeOfTB(checkEntryValue, ViewResultTB)) {
-      await this._checkViewFunction(contract, method, { result: checkEntryValue });
-    } else {
-      logErrorAndExit(`Unknown check type: ${JSON.stringify(checkEntryValue)}`);
     }
   }
 }

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -43,9 +43,9 @@ export let g_Arguments: ReturnType<typeof parseCommandLineArguments>;
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unreachable code error
 // eslint-disable-next-line unicorn/no-nonstandard-builtin-properties -- deliberate polyfill for JSON.stringify of bigints
-BigInt.prototype.toJSON = function (): number {
+BigInt.prototype.toJSON = function (): string {
   // eslint-disable-next-line unicorn/no-this-outside-of-class -- prototype method
-  return Number(this);
+  return this.toString();
 };
 
 function formatAjvErrors(errors: ValidateFunction["errors"]) {

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -40,8 +40,12 @@ import { ContractInfo } from "./types";
 
 export let g_Arguments: ReturnType<typeof parseCommandLineArguments>;
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: Unreachable code error
+declare global {
+  interface BigInt {
+    toJSON(): string;
+  }
+}
+
 // eslint-disable-next-line unicorn/no-nonstandard-builtin-properties -- deliberate polyfill for JSON.stringify of bigints
 BigInt.prototype.toJSON = function (): string {
   // eslint-disable-next-line unicorn/no-this-outside-of-class -- prototype method
@@ -270,7 +274,6 @@ async function main() {
   }
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/prefer-await -- CommonJS entrypoint
 main().catch((error) => {
   logError(error);
   process.exitCode = 1;

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -270,7 +270,7 @@ async function main() {
   }
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
+// eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/prefer-await -- CommonJS entrypoint
 main().catch((error) => {
   logError(error);
   process.exitCode = 1;

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -18,7 +18,7 @@ import {
   resetAbiModeCache,
 } from "./abi-provider";
 import { doGenerateBoilerplate } from "./boilerplate-generator";
-import { parseCmdLineArguments } from "./cli-parser";
+import { parseCommandLineArguments } from "./cli-parser";
 import { printError, readUrlOrFromEnvironment } from "./common";
 import { loadContractInfoFromExplorer } from "./explorer-provider";
 import { FAILURE_MARK, log, logError, logErrorAndExit, logHeader1, SUCCESS_MARK, WARNING_MARK } from "./logger";
@@ -38,11 +38,13 @@ import {
 } from "./typebox";
 import { ContractInfo } from "./types";
 
-export let g_Arguments: ReturnType<typeof parseCmdLineArguments>;
+export let g_Arguments: ReturnType<typeof parseCommandLineArguments>;
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unreachable code error
+// eslint-disable-next-line unicorn/no-nonstandard-builtin-properties -- deliberate polyfill for JSON.stringify of bigints
 BigInt.prototype.toJSON = function (): number {
+  // eslint-disable-next-line unicorn/no-this-outside-of-class -- prototype method
   return Number(this);
 };
 
@@ -137,7 +139,7 @@ async function doChecks(jsonDocument: EntireDocument) {
           `\n${chalk.red(`[${index + 1}/${g_error_details.length}]`)} ` +
             `${chalk.cyan("Section:")} ${chalk.yellow(error.section)} | ` +
             `${chalk.cyan("Contract:")} ${chalk.yellow(error.contract)} ` +
-            `${chalk.gray(`(${error.contractAddress})`)}` +
+            chalk.gray(`(${error.contractAddress})`) +
             `\n    ${chalk.cyan("Check Type:")} ${chalk.yellow(error.checksType)} | ` +
             `${chalk.cyan("Method:")} ${chalk.yellow(error.method)}` +
             `\n    ${chalk.cyan("Error:")} ${chalk.red(error.message)}`,
@@ -229,7 +231,7 @@ async function checkNetworkSection(sectionTitle: string, section: NetworkSection
 }
 
 async function main() {
-  g_Arguments = parseCmdLineArguments();
+  g_Arguments = parseCommandLineArguments();
 
   if (g_Arguments.updateAbi) {
     renameAllAbiToLowerCase();

--- a/src/test-util/app.ts
+++ b/src/test-util/app.ts
@@ -29,8 +29,8 @@ class Result {
     const checksMatch = response.match(/(\d+) checks performed/);
     const errorsMatch = response.match(/(\d+) errors found/);
 
-    this.checks = checksMatch ? Number.parseInt(checksMatch[1], 10) : undefined;
-    this.errors = errorsMatch ? Number.parseInt(errorsMatch[1], 10) : 0;
+    this.checks = checksMatch ? Number(checksMatch[1]) : undefined;
+    this.errors = errorsMatch ? Number(errorsMatch[1]) : 0;
   }
   isValid(): boolean {
     return !!this?.checks;
@@ -232,5 +232,5 @@ async function main() {
   processAllYamlFolders(yamlFolderAbsolutePath, requiredFolders, environmentVariables);
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
+// eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/prefer-await -- CommonJS entrypoint
 main().catch((error) => console.error(error));

--- a/src/test-util/app.ts
+++ b/src/test-util/app.ts
@@ -61,7 +61,7 @@ class ResultsMatcher {
     if (!this.forkResult || !this.originResult) return "";
     const print = (forkCounter?: number, originCounter?: number): string => {
       const report = `${forkCounter ?? 0} vs ${originCounter ?? 0}`;
-      return `${forkCounter === originCounter ? chalk.green(report) : chalk.red(report)}`;
+      return forkCounter === originCounter ? chalk.green(report) : chalk.red(report);
     };
 
     const formattedReport =
@@ -79,12 +79,14 @@ const FORK_REPO_PATH: string = process.cwd();
 let ORIGIN_REPO_PATH: string;
 
 function setEnvironmentsFromFolder(folder: string, environmentVariables?: EnvironmentVariables) {
-  if (environmentVariables && environmentVariables[folder]) {
-    Object.assign(process.env, environmentVariables[folder]);
-    log(
-      `The following environment variables are additionally set:\n ${JSON.stringify(environmentVariables[folder], null, 2)}`,
-    );
+  if (!(environmentVariables && Object.hasOwn(environmentVariables, folder))) {
+    return;
   }
+
+  Object.assign(process.env, environmentVariables[folder]);
+  log(
+    `The following environment variables are additionally set:\n ${JSON.stringify(environmentVariables[folder], null, 2)}`,
+  );
 }
 
 function processAllYamlFolders(
@@ -178,10 +180,9 @@ function runStateMate(yamlFileAbsolutePath: string, options?: string): Response 
       logHandler.failure("Failed with report");
     }
     return { result, output };
-  } else {
-    logHandler.failure("Failed without report");
-    return {};
   }
+  logHandler.failure("Failed without report");
+  return {};
 }
 
 function run(command: string): string | null {

--- a/src/test-util/app.ts
+++ b/src/test-util/app.ts
@@ -232,5 +232,4 @@ async function main() {
   processAllYamlFolders(yamlFolderAbsolutePath, requiredFolders, environmentVariables);
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/prefer-await -- CommonJS entrypoint
 main().catch((error) => console.error(error));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@adraffy/ens-normalize@npm:1.11.1":
@@ -4018,11 +4018,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
-  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/eed465bd04b344517bd91eb232fd0187d93e34625c65ec93777449e29157c6c2accae409474a68a867b90465224d4908f9bce78ad763c159cacd7263ae24b5fc
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3700,6 +3700,9 @@ __metadata:
     tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:^6.0.3"
     yaml: "npm:^2.9.0"
+  dependenciesMeta:
+    unrs-resolver:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- Skill: deployment verification playbook (`references/verification-playbook.md`), refreshed patterns, Safe-as-proxy stanza, troubleshooting.
- `_findAbiPath`: address fallback now opt-in. Etherscan resolves proxy addresses to implementation ABIs, and the old default let the impl ABI overwrite `OssifiableProxy-*.json` on `--update-abi`. Also honours `shouldThrow` in the early exit.
- `--generate`: strips the real seed extension, so `.yml` seeds no longer produce `x.seed.yml.generated.yaml`.
- eslint-plugin-unicorn v69 (merged in #144) left `yarn lint` with 122 errors: 49 fixed in code, 5 opinionated rules disabled with reasons in `eslint.config.mjs` (started at 9, four re-enabled after fixing their violations).
- Inline `eslint-disable` comments reduced 6 → 2: `@ts-ignore` replaced with a `BigInt.toJSON` type augmentation, entrypoint rules moved to a files override.
- `BigInt.prototype.toJSON` serializes as string: full precision for uint256 values in error messages.
- CI on Node 22: unicorn v69 calls `Set.prototype.union`, absent on Node 20 runners.
- yarn 4.17: install scripts gated behind a `dependenciesMeta` whitelist (`unrs-resolver` only), npm age gate kept at default.

Validation: `yarn lint` and `yarn format` clean, zero unused disable directives, `lido.yaml -o l1/lidoLocator` against a mainnet fork passes 51/51.