### PR TITLE
fix: report checks accurately and update Hoodi role

### DIFF
--- a/configs/lido/hoodi/lido-testnet.yaml
+++ b/configs/lido/hoodi/lido-testnet.yaml
@@ -1228,7 +1228,7 @@ l1:
       ozAcl:
         *DEFAULT_ADMIN_ROLE : [*aragonAgent, *csmManager]
         *CS_MANAGE_BOND_CURVES_ROLE : []
-        *CS_SET_BOND_CURVE_ROLE : [*csmManager, *CSVettedGate, *identifiedDvtClusterGate]
+        *CS_SET_BOND_CURVE_ROLE : [*CSVettedGate, *identifiedDvtClusterGate]
         *CS_RECOVERER_ROLE : []
         *CS_RESUME_ROLE : [*resealManager]
         *CS_PAUSE_ROLE : [*resealManager, *circuitBreaker]

--- a/src/section-validators/base.ts
+++ b/src/section-validators/base.ts
@@ -29,11 +29,15 @@ export interface ErrorDetail {
 
 export let g_errors: number = 0;
 export let g_total_checks: number = 0;
+export let g_passed_checks: number = 0;
+export let g_skipped_checks: number = 0;
 export const g_error_details: ErrorDetail[] = [];
 
 // Per-contract counters
 let g_contract_errors: number = 0;
 let g_contract_checks: number = 0;
+let g_contract_passed: number = 0;
+let g_contract_skipped: number = 0;
 
 let g_current_context: Partial<ErrorDetail> = {};
 
@@ -48,10 +52,17 @@ export function clearErrorContext(): void {
 export function resetContractCounters(): void {
   g_contract_errors = 0;
   g_contract_checks = 0;
+  g_contract_passed = 0;
+  g_contract_skipped = 0;
 }
 
-export function getContractStats(): { checks: number; errors: number } {
-  return { checks: g_contract_checks, errors: g_contract_errors };
+export function getContractStats(): { checks: number; errors: number; passed: number; skipped: number } {
+  return {
+    checks: g_contract_checks,
+    errors: g_contract_errors,
+    passed: g_contract_passed,
+    skipped: g_contract_skipped,
+  };
 }
 
 export function incErrors(errorMessage?: string): void {
@@ -72,6 +83,16 @@ export function incErrors(errorMessage?: string): void {
 export function incChecks(): void {
   g_total_checks += 1;
   g_contract_checks += 1;
+}
+
+export function incPassed(): void {
+  g_passed_checks += 1;
+  g_contract_passed += 1;
+}
+
+export function incSkipped(): void {
+  g_skipped_checks += 1;
+  g_contract_skipped += 1;
 }
 
 export enum CheckLevel {
@@ -113,6 +134,7 @@ export abstract class SectionValidatorBase {
 
   protected async _checkViewResult(contract: Contract, method: string, staticCallResult: StaticCallResult) {
     if (staticCallResult.result === null) {
+      incSkipped();
       logMethodSkipped(method);
       return;
     }
@@ -136,6 +158,7 @@ export abstract class SectionValidatorBase {
     try {
       const actual: unknown = await contractFunction.staticCall(...(args || ""));
       _assertEqual(actual, expected);
+      incPassed();
       logHandle.success(_stringify(actual));
     } catch (error) {
       const errorMessage = `REVERTED with: ${printError(error)}`;
@@ -167,6 +190,7 @@ export abstract class SectionValidatorBase {
       logHandle.failure(errorMessage);
       incErrors(errorMessage);
     } catch (error) {
+      incPassed();
       logHandle.success(`REVERTED with: ${printError(error)}`);
     }
   }

--- a/src/section-validators/base.ts
+++ b/src/section-validators/base.ts
@@ -102,7 +102,6 @@ export abstract class SectionValidatorBase {
   ): Promise<void>;
 
   protected async _checkViewFunction(contract: Contract, method: string, staticCallCheck: StaticCallCheck) {
-    incChecks();
     if (isTypeOfTB(staticCallCheck, StaticCallResultTB)) {
       await this._checkViewResult(contract, method, staticCallCheck);
     } else if (isTypeOfTB(staticCallCheck, StaticCallMustRevertTB)) {
@@ -117,6 +116,7 @@ export abstract class SectionValidatorBase {
       logMethodSkipped(method);
       return;
     }
+    incChecks();
 
     const { args, result: expected, signature = method } = staticCallResult;
 
@@ -145,6 +145,7 @@ export abstract class SectionValidatorBase {
   }
 
   protected async _checkViewMustRevert(contract: Contract, method: string, staticCallMustRevert: StaticCallMustRevert) {
+    incChecks();
     const { args, signature = method } = staticCallMustRevert;
 
     const argumentsString = args ? `(${args.toString()})` : "";

--- a/src/section-validators/contract.ts
+++ b/src/section-validators/contract.ts
@@ -120,10 +120,11 @@ export class ContractSectionValidator {
     clearErrorContext();
 
     // Show contract status (not last, global status follows)
-    const { checks, errors } = getContractStats();
+    const { errors, passed, skipped } = getContractStats();
+    const successfulChecks = `${passed} passed, ${skipped} skipped`;
     const statusMessage = errors
-      ? `${checks} checks, ${chalk.red(`${errors} ${errors === 1 ? "error" : "errors"}`)}`
-      : `${checks} checks passed`;
+      ? `${successfulChecks}, ${chalk.red(`${errors} ${errors === 1 ? "error" : "errors"}`)}`
+      : successfulChecks;
     logFinalStatus(statusMessage, errors === 0, true);
   }
 }

--- a/src/section-validators/oz-non-enumerable-acl.ts
+++ b/src/section-validators/oz-non-enumerable-acl.ts
@@ -8,7 +8,7 @@ import { log, LogCommand, logHeader2, WARNING_MARK } from "src/logger";
 import { ContractEntry, isTypeOfTB, ProxyContractEntryTB } from "src/typebox";
 import { Abi } from "src/types";
 
-import { incChecks, incErrors, SectionValidatorBase, setErrorContext } from "./base";
+import { incChecks, incErrors, incPassed, SectionValidatorBase, setErrorContext } from "./base";
 
 export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
   constructor(provider: JsonRpcProvider) {
@@ -74,6 +74,7 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
         try {
           const isRoleOnHolder: unknown = await contract.getFunction("hasRole").staticCall(role, holder);
           assert.isTrue(isRoleOnHolder);
+          incPassed();
           logHandle.success(String(isRoleOnHolder));
         } catch (error) {
           const errorMessage = `REVERTED with: ${(error as Error).message}`;
@@ -96,6 +97,7 @@ export class OzNonEnumerableAclSectionValidator extends SectionValidatorBase {
         try {
           const isRoleOnHolder: unknown = await contract.getFunction("hasRole").staticCall(role, holder);
           assert.isFalse(isRoleOnHolder);
+          incPassed();
           logHandle.success(String(isRoleOnHolder));
         } catch (error) {
           const errorMessage = `REVERTED with: ${(error as Error).message}`;

--- a/src/section-validators/storage.ts
+++ b/src/section-validators/storage.ts
@@ -4,7 +4,7 @@ import { EntryField } from "src/common";
 import { logHeader2, LogCommand } from "src/logger";
 import { ContractEntry } from "src/typebox";
 
-import { incChecks, incErrors, SectionValidatorBase, setErrorContext } from "./base";
+import { incChecks, incErrors, incPassed, SectionValidatorBase, setErrorContext } from "./base";
 
 /**
  * Normalizes a hex value to a 32-byte (64 hex chars + 0x prefix = 66 chars) representation.
@@ -58,6 +58,7 @@ export class StorageSectionValidator extends SectionValidatorBase {
         const normalizedExpected = normalizeToBytes32(expectedValue);
 
         if (normalizedActual === normalizedExpected) {
+          incPassed();
           logHandle.success(actual);
         } else {
           const errorMessage = `Expected "${expectedValue}" but got "${actual}"`;

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -22,7 +22,7 @@ import { parseCommandLineArguments } from "./cli-parser";
 import { printError, readUrlOrFromEnvironment } from "./common";
 import { loadContractInfoFromExplorer } from "./explorer-provider";
 import { FAILURE_MARK, log, logError, logErrorAndExit, logHeader1, SUCCESS_MARK, WARNING_MARK } from "./logger";
-import { g_error_details, g_errors, g_total_checks } from "./section-validators/base";
+import { g_error_details, g_errors, g_passed_checks, g_skipped_checks } from "./section-validators/base";
 import { ContractSectionValidator } from "./section-validators/contract";
 import {
   EntireDocument,
@@ -126,9 +126,8 @@ async function doChecks(jsonDocument: EntireDocument) {
   // Show final summary (outside the tree)
   log(""); // Separator line
   const statusMark = g_errors ? FAILURE_MARK : SUCCESS_MARK;
-  const statusMessage = g_errors
-    ? `${g_total_checks} checks, ${chalk.red(`${g_errors} errors`)}`
-    : `${g_total_checks} checks passed`;
+  const successfulChecks = `${g_passed_checks} passed, ${g_skipped_checks} skipped`;
+  const statusMessage = g_errors ? `${successfulChecks}, ${chalk.red(`${g_errors} errors`)}` : successfulChecks;
   log(`${statusMark} ${chalk.bold("Total:")} ${statusMessage}`);
 
   if (g_Arguments.checkOnly) {


### PR DESCRIPTION
## What changed

- exclude checks with a null expected result from executed check totals
- log passed and skipped counts per contract and in the final summary
- remove csmManager from the Hoodi CS_SET_BOND_CURVE_ROLE expectation

## Why

The validator incremented the check counter before handling null. A skipped method was therefore reported as passed even though state-mate made no contract call.

The Hoodi config should no longer expect csmManager to hold CS_SET_BOND_CURVE_ROLE.

## Validation

- yarn lint
- yarn format
- yarn tsc --ignoreDeprecations 6.0 --noEmit
- yarn prettier configs/lido/hoodi/lido-testnet.yaml --check

The existing TypeScript 6 baseUrl deprecation on main still blocks yarn build.