### PR TITLE
feat: pin the ProxyAdmin address behind transparent proxies

### DIFF
--- a/.claude/skills/state-mate/skill.md
+++ b/.claude/skills/state-mate/skill.md
@@ -79,7 +79,7 @@ contractName:
 
 ### Proxy patterns
 
-**Transparent Upgradeable Proxy**. `proxyChecks: {}` because the admin/impl live in EIP-1967 slots. The implementation slot is verified for every entry automatically, and `proxyAdminOwner:` covers who controls the ProxyAdmin in the admin slot without a separate `ProxyAdmin` entry. Pin the admin address itself via `storage:` when you want both:
+**Transparent Upgradeable Proxy**. `proxyChecks: {}` because the admin/impl live in EIP-1967 slots. The implementation slot is verified for every entry automatically. `proxyAdmin:` pins the contract the admin slot holds, `proxyAdminOwner:` pins the address that controls it one hop further, and neither needs a separate `ProxyAdmin` entry or its ABI. Declare both: an unexpected ProxyAdmin owned by the expected owner passes the owner check alone.
 
 ```yaml
 contractName:
@@ -87,12 +87,9 @@ contractName:
   address: *contractAddress
   proxyName: TransparentUpgradeableProxy
   implementation: *implementationAddress
+  proxyAdmin: "0x0000000000000000000000000000000000000000" # the ProxyAdmin in the EIP-1967 admin slot
   proxyAdminOwner: *ownerOfTheProxyAdmin
   proxyChecks: {}
-  storage:
-    - slot: *EIP1967_ADMIN_SLOT
-      expected: *proxyAdminAddress
-      label: admin
   checks:
     # against the proxy (implementation logic, proxy state)
     someFunction: expectedValue

--- a/configs/lido-earn/mainnet/earneth-vaults.yaml
+++ b/configs/lido-earn/mainnet/earneth-vaults.yaml
@@ -229,6 +229,7 @@ l1:
       address: *vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x8b781593B273391428fe0E9deD0c2FFc3D6bFF37"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -558,6 +559,7 @@ l1:
       address: *depositQueueETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x94bc347B510ae93226fDfbD6B41A6a057Cd6A05e"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -584,6 +586,7 @@ l1:
       address: *syncDepositQueueETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xE4b1CaCA6FF8c04a2f8BC863BD3C1e2922EF2313"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -614,6 +617,7 @@ l1:
       address: *depositQueueWETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0xec20Dd518E7a70304c4453bcbD988FC7eaB4Bd84"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -640,6 +644,7 @@ l1:
       address: *syncDepositQueueWETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xe7b24BE0dcaE1539661C4c42abdcE070e432D130"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -670,6 +675,7 @@ l1:
       address: *depositQueueWstETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0xeF3D010d1ce6A4F7427bB13223808f64c6a50b94"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -696,6 +702,7 @@ l1:
       address: *syncDepositQueueWstETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x529f500F569Ac7552aDDd3b2aF374Fa4535e9a0E"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -726,6 +733,7 @@ l1:
       address: *redeemQueueWstETH
       proxyName: TransparentUpgradeableProxy
       implementation: *redeemQueueImplementation
+      proxyAdmin: "0x87bA1e6d4410AE361773D219c00d427024a62079"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -755,6 +763,7 @@ l1:
       address: *syncRedeemQueueWstETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0x4273E3c7c6B7c3d25DBc6a46353a79195c5D2A5D"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -787,6 +796,7 @@ l1:
       address: *depositQueueGG
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0xEF9d907A485728CB8096cD47FbB6861ACD739BE8"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -813,6 +823,7 @@ l1:
       address: *syncDepositQueueGG
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xb3312a94BC9a38526632E4a28E9347015d20c4E4"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -843,6 +854,7 @@ l1:
       address: *depositQueueStrETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x9F2Db5FBd61AfaD6e8581f13194e0dC43236D3ba"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -869,6 +881,7 @@ l1:
       address: *syncDepositQueueStrETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xF9BD69848275acc43b3B367Dd98EDd2a626202Af"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -899,6 +912,7 @@ l1:
       address: *depositQueueDVstETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x677016c88E6D77155a3C7eEa820d54F43274786a"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -925,6 +939,7 @@ l1:
       address: *syncDepositQueueDVstETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x195ff2C1FA52790DAA1936d0151C2337c368e5f4"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -955,6 +970,7 @@ l1:
       address: *oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0xc7cbd334CA805ADA4FF01fB8851Ee064793c1Cdf"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1054,6 +1070,7 @@ l1:
       address: *shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *burnableShareManagerImplementation
+      proxyAdmin: "0xfCFBFa1911Ef1Cd79BB1CE9E8a3823a16676E907"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1111,6 +1128,7 @@ l1:
       address: *feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0x46cC26196eECf838631Da8173353f7664123A759"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1149,6 +1167,7 @@ l1:
       address: *riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0xfbaAc742311411C15eCa1D811ADF88Df3e8972D9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1201,6 +1220,7 @@ l1:
       address: *subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x15Cd062dC7dCBB3C8da2804dc62Db35F3Abc5209"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1223,6 +1243,7 @@ l1:
       address: *verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xBb11664320534fe11fFfAC3813b0B4721629F84C"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1261,6 +1282,7 @@ l1:
       address: *subvault1
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x518Aa49c8Ff07277EAE8687858f9870F95737f2A"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1283,6 +1305,7 @@ l1:
       address: *verifier1
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x0Fd1DC0ad3E08467F9f4FDCA93585b452279ffc9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1764,6 +1787,7 @@ l1:
       address: *factoryFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xf004f5876D352533fB8b244f1f6227caA8efF867"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1794,6 +1818,7 @@ l1:
       address: *depositQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x77da14F966385b19c6e2D99a4448dcFc6FC53985"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1836,6 +1861,7 @@ l1:
       address: *redeemQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xFce5f4F214288248F827390223F825dFb8c452be"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1878,6 +1904,7 @@ l1:
       address: *feeManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x34BE100C59e7214Ac3382CD5d3E143e8D5107692"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1908,6 +1935,7 @@ l1:
       address: *oracleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x03B10BC6ccaa3e7e894f7d0Bac1003BB843F14BF"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1938,6 +1966,7 @@ l1:
       address: *riskManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x2eBD4375F9DEd72ed36D49973AeBf182e0e4482c"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1968,6 +1997,7 @@ l1:
       address: *shareManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x93Ef6F26BFDCe31CA6D12cCf51e5bE9a95586B08"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2006,6 +2036,7 @@ l1:
       address: *subvaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc70e0E18dd7e6239E2808f48Ea9BE4cD77b405af"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2036,6 +2067,7 @@ l1:
       address: *verifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc5e76f98C8B6D3f536C2Ea77DE170de34A259341"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2066,6 +2098,7 @@ l1:
       address: *vaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xe7AfA247103BDc7dE9054241669741A425Fa5A26"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2096,6 +2129,7 @@ l1:
       address: *consensusFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x50104e78C849B94D9D895e7888Bc464cc1811F89"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2126,6 +2160,7 @@ l1:
       address: *eigenLayerVerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xd9d37156529646743B990973a2C3Bad98ceB70a9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2156,6 +2191,7 @@ l1:
       address: *erc20VerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x8283eeB88ff09bD49CdCe79887C9b7854eCa0697"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2186,6 +2222,7 @@ l1:
       address: *symbioticVerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xC885556d679e959Da6331F0590D8c8d4a9302848"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2216,6 +2253,7 @@ l1:
       address: *swapModuleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x214cC3E0BF23E141739dEae7014b1c1fDB3b4e21"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:

--- a/configs/lido-earn/mainnet/earnusd-vaults-base.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-base.yaml
@@ -162,6 +162,7 @@ l1:
       address: *earnUSDc_vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x821248FE1C1CEFace02D87936b89C49D95eC4E41"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -328,6 +329,7 @@ l1:
       address: *earnUSDc_subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x193afe84E9ED5F6E8aC98A382117955d3B584f5f"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -350,6 +352,7 @@ l1:
       address: *earnUSDc_verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x6061E0bb12947cCD8F3D0dE9B002846dE15873C1"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -388,6 +391,7 @@ l1:
       address: *earnUSDc_oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0xAaC1448680A5BAc7b6Fc16F40D02eBad9434De31"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -462,6 +466,7 @@ l1:
       address: *earnUSDc_shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *shareManagerImplementation
+      proxyAdmin: "0x36f015103e7146865468C8E2FeECBe74b431Cb65"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -519,6 +524,7 @@ l1:
       address: *earnUSDc_feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0xF6f69692F6fB2dAb40eF262612A63Ffb2F1BbBac"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -557,6 +563,7 @@ l1:
       address: *earnUSDc_riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x51644274Bb3E514637A4EF3b25eF6D67CB8D08C9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:

--- a/configs/lido-earn/mainnet/earnusd-vaults-ethereum.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-ethereum.yaml
@@ -285,6 +285,7 @@ l1:
       address: *earnUSD_vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0xCf2a17F9fE0A2d817D89D7c1EDd57b218c0Bd20b"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -543,6 +544,7 @@ l1:
       address: *earnUSD_subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x438211fdbDf4b424F877f623Db6BE3a9e38E5729"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -565,6 +567,7 @@ l1:
       address: *earnUSD_verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x1E706382237146c06e6D0D21F000aD0B26637746"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -603,6 +606,7 @@ l1:
       address: *earnUSD_subvault1
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x25E02242E25d1180eaAFe68Aa33cd474ddf30f74"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -625,6 +629,7 @@ l1:
       address: *earnUSD_verifier1
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x0808e9b3104676CF43C2f9d243ce9c5ad3236C70"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -663,6 +668,7 @@ l1:
       address: *earnUSD_depositQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0xf74aEfF4A87BF3D0A06C1EABD01b5A7d3A8a18d5"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -689,6 +695,7 @@ l1:
       address: *earnUSD_syncDepositQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x1bB9006ba5f5F7fBd5Cef6c6DD40Ff546c0b71DB"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -719,6 +726,7 @@ l1:
       address: *earnUSD_redeemQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *redeemQueueImplementation
+      proxyAdmin: "0x099874d0aE9E717fb9a8F52359A2B97551DCAb0F"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -748,6 +756,7 @@ l1:
       address: *earnUSD_syncRedeemQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0x87f2a0E7B58fe984b2f45c4bE0AB93b2eb352BFA"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -780,6 +789,7 @@ l1:
       address: *earnUSD_depositQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x21BB6Fd0d713E99Bd0EBa9a1Df19387d17D4A672"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -806,6 +816,7 @@ l1:
       address: *earnUSD_syncDepositQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x37E7176616a1AB7aB016D637553F4FcaCC5f059B"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -836,6 +847,7 @@ l1:
       address: *earnUSD_redeemQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *redeemQueueImplementation
+      proxyAdmin: "0x040f9303f86069176015bc34BB0E313A9Aff26bB"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -865,6 +877,7 @@ l1:
       address: *earnUSD_depositQueueUSDe
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x0EFDf7dFb10253697917499c18ED170B6fF0c19b"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -891,6 +904,7 @@ l1:
       address: *earnUSD_oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x197ff65B13C9cAD57fBe693e398F093A99812653"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -983,6 +997,7 @@ l1:
       address: *earnUSD_shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *burnableShareManagerImplementation
+      proxyAdmin: "0x98A876B68EECB730E692D0Ec699B3378bdc71d6f"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1040,6 +1055,7 @@ l1:
       address: *earnUSD_feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0x291430F5db35e60d5BE560Ec0d524c60AAee66c5"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1078,6 +1094,7 @@ l1:
       address: *earnUSD_riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x5e8a12aB4eB9fc61cF8D72B52e4C8a207C3b09e6"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1189,6 +1206,7 @@ l1:
       address: *earnUSDc_vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x504dE36F365B0aD3c941312897190af4f67f76Eb"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1406,6 +1424,7 @@ l1:
       address: *earnUSDc_subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x6D0BB3b3B6D1e9Cd051221353B389F3bB3D834c7"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1428,6 +1447,7 @@ l1:
       address: *earnUSDc_verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x47ff4a8eC8b8e815BEF7a745197e06001AA75D57"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1466,6 +1486,7 @@ l1:
       address: *earnUSDc_syncDepositQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x7143799bBa27F00f84a0695ce7d414A9a7221c86"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1496,6 +1517,7 @@ l1:
       address: *earnUSDc_redeemQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *redeemQueueImplementation
+      proxyAdmin: "0x260738C61B252B9Fed7F9174D4642F423ad9f2e9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1525,6 +1547,7 @@ l1:
       address: *earnUSDc_syncRedeemQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0x67AA0F8Ed5b5488Da96186a582eBaAd1C37050A6"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1557,6 +1580,7 @@ l1:
       address: *earnUSDc_syncDepositQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xE66F48139ECd710320A4f108b6c9eE9A94A25fbd"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1587,6 +1611,7 @@ l1:
       address: *earnUSDc_syncRedeemQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0x5D89E823D5d0fD13b3e83505F316a70Ce9038146"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1619,6 +1644,7 @@ l1:
       address: *earnUSDc_oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x689d165B8c49762Aeb643CAA1665880742Eb40Fa"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1707,6 +1733,7 @@ l1:
       address: *earnUSDc_shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *burnableShareManagerImplementation
+      proxyAdmin: "0xE9faE053AB77ec83ff0495221C5540bBDA8cbad2"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1764,6 +1791,7 @@ l1:
       address: *earnUSDc_feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0xc2d7ce8746F90685E1e923494E17937f5f7794d9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1802,6 +1830,7 @@ l1:
       address: *earnUSDc_riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0xC294004857dC9B8e8246ac8704Df08722100ac4b"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1854,6 +1883,7 @@ l1:
       address: *earnUSDc_swapModule0
       proxyName: TransparentUpgradeableProxy
       implementation: *swapModuleImplementation
+      proxyAdmin: "0x6D16E5793415e656f0Dd5a0E7c9D0B5A4655cb27"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -1978,6 +2008,7 @@ l1:
       address: *earnUSDe_vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x95Ad8A8597D55fe2082190cD504Cc162C97266Ca"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2208,6 +2239,7 @@ l1:
       address: *earnUSDe_subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x25a44474fE072d6A3aa8910d8E7727D35d500C87"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2230,6 +2262,7 @@ l1:
       address: *earnUSDe_verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xb90eC48b4DE74806ddf455B1eFC334b3e76c0fA3"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2268,6 +2301,7 @@ l1:
       address: *earnUSDe_syncDepositQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xCc53dB7AD5f8BE190806846e6eF70e029A62Ec48"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2298,6 +2332,7 @@ l1:
       address: *earnUSDe_redeemQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *redeemQueueImplementation
+      proxyAdmin: "0x1c56bBB70B4b22AbF4f91f8aB4F5D268fd9674D7"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2327,6 +2362,7 @@ l1:
       address: *earnUSDe_syncRedeemQueueUSDC
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0x989138E789D4cF53cAd9B25F5F3420220502F3Cc"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2359,6 +2395,7 @@ l1:
       address: *earnUSDe_syncDepositQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x3b131eE930328B4b8fC9ea4586Bae83106CEC4AD"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2389,6 +2426,7 @@ l1:
       address: *earnUSDe_syncRedeemQueueUSDT
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0x7F8d3f739B5571877903e8Cd2E83cf1A6fB16edD"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2421,6 +2459,7 @@ l1:
       address: *earnUSDe_syncDepositQueueUSDe
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xc44681612aFd98C599949dfEB64679cDfa2fE2d7"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2451,6 +2490,7 @@ l1:
       address: *earnUSDe_oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x45d5eE9dbF6F493772A44C6e6B46CDE53789712E"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2543,6 +2583,7 @@ l1:
       address: *earnUSDe_shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *burnableShareManagerImplementation
+      proxyAdmin: "0x85673C92008C17294499819f678AA3220d927d51"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2600,6 +2641,7 @@ l1:
       address: *earnUSDe_feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0xCe6eAf94DC5196727218034d60bF7FAd58507dBe"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2638,6 +2680,7 @@ l1:
       address: *earnUSDe_riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x00b1b75CAd50Ea30a26083B60D44Ac4457D654a6"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -2690,6 +2733,7 @@ l1:
       address: *earnUSDe_swapModule0
       proxyName: TransparentUpgradeableProxy
       implementation: *swapModuleImplementation
+      proxyAdmin: "0xc7135Ff08856BDAB0ecA5dD12C3Fe15f352A94e1"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3249,6 +3293,7 @@ l1:
       address: *factoryFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xf004f5876D352533fB8b244f1f6227caA8efF867"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3279,6 +3324,7 @@ l1:
       address: *depositQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x77da14F966385b19c6e2D99a4448dcFc6FC53985"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3321,6 +3367,7 @@ l1:
       address: *redeemQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xFce5f4F214288248F827390223F825dFb8c452be"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3363,6 +3410,7 @@ l1:
       address: *feeManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x34BE100C59e7214Ac3382CD5d3E143e8D5107692"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3393,6 +3441,7 @@ l1:
       address: *oracleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x03B10BC6ccaa3e7e894f7d0Bac1003BB843F14BF"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3423,6 +3472,7 @@ l1:
       address: *riskManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x2eBD4375F9DEd72ed36D49973AeBf182e0e4482c"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3453,6 +3503,7 @@ l1:
       address: *shareManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x93Ef6F26BFDCe31CA6D12cCf51e5bE9a95586B08"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3491,6 +3542,7 @@ l1:
       address: *subvaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc70e0E18dd7e6239E2808f48Ea9BE4cD77b405af"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3521,6 +3573,7 @@ l1:
       address: *verifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc5e76f98C8B6D3f536C2Ea77DE170de34A259341"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3551,6 +3604,7 @@ l1:
       address: *vaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xe7AfA247103BDc7dE9054241669741A425Fa5A26"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3581,6 +3635,7 @@ l1:
       address: *consensusFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x50104e78C849B94D9D895e7888Bc464cc1811F89"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3611,6 +3666,7 @@ l1:
       address: *eigenLayerVerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xd9d37156529646743B990973a2C3Bad98ceB70a9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3641,6 +3697,7 @@ l1:
       address: *erc20VerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x8283eeB88ff09bD49CdCe79887C9b7854eCa0697"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3671,6 +3728,7 @@ l1:
       address: *symbioticVerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xC885556d679e959Da6331F0590D8c8d4a9302848"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -3701,6 +3759,7 @@ l1:
       address: *swapModuleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x214cC3E0BF23E141739dEae7014b1c1fDB3b4e21"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:

--- a/configs/lido-earn/mainnet/earnusd-vaults-mantle.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-mantle.yaml
@@ -181,6 +181,7 @@ l1:
       address: *earnUSDe_vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x8aBB0f063d3291FDeB1931F9E4F323839c21204e"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -347,6 +348,7 @@ l1:
       address: *earnUSDe_subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x3F8374EEA0c2c26e5C63de95E1454EA076feCe27"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -369,6 +371,7 @@ l1:
       address: *earnUSDe_verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xf646267F442f8FA5C41b0740b71ebDf9b0828a87"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -407,6 +410,7 @@ l1:
       address: *earnUSDe_swapModule0
       proxyName: TransparentUpgradeableProxy
       implementation: *swapModuleImplementation
+      proxyAdmin: "0x9DBE20e845B67B35A8B8080B710091B0C686b5fB"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -473,6 +477,7 @@ l1:
       address: *earnUSDe_oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x116459Ea4348B11744D73Ca4239314B0562DB7CE"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -537,6 +542,7 @@ l1:
       address: *earnUSDe_shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *earnUSDe_shareManagerImplementation
+      proxyAdmin: "0x2FEe4ff3aEDfE282b429eEEE35E640F09293c957"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -594,6 +600,7 @@ l1:
       address: *earnUSDe_feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0xF6f69692F6fB2dAb40eF262612A63Ffb2F1BbBac"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -632,6 +639,7 @@ l1:
       address: *earnUSDe_riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x51644274Bb3E514637A4EF3b25eF6D67CB8D08C9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:

--- a/configs/lido-earn/mainnet/earnusd-vaults-plasma.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-plasma.yaml
@@ -185,6 +185,7 @@ l1:
       address: *earnUSDe_vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0xc9F42CFcFdF17479114e8dbF3607954080d38653"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -354,6 +355,7 @@ l1:
       address: *earnUSDe_subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0xFF5124787C2aDB77c064497dc20de0d022229930"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -376,6 +378,7 @@ l1:
       address: *earnUSDe_verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x252F43BF2863830a33D8865046183EAf795767C7"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -414,6 +417,7 @@ l1:
       address: *earnUSDe_subvault1
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0xC7F37769657D4ef023bd180376F4C37b786a445E"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -436,6 +440,7 @@ l1:
       address: *earnUSDe_verifier1
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xeDDC9e0Cca1A039688d2Ac008657841F7D173c5d"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -474,6 +479,7 @@ l1:
       address: *earnUSDe_swapModule0
       proxyName: TransparentUpgradeableProxy
       implementation: *swapModuleImplementation
+      proxyAdmin: "0x4ce3095A7BEfd4bbEC27025D39E7eF680d86Da20"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -540,6 +546,7 @@ l1:
       address: *earnUSDe_oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x145e195b5d3072c5a5dA923c70e84Fc7E63de2ca"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -608,6 +615,7 @@ l1:
       address: *earnUSDe_shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *earnUSDe_shareManagerImplementation
+      proxyAdmin: "0xe91F985fA14ca024c5880BA7910A97b134E1D47f"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -665,6 +673,7 @@ l1:
       address: *earnUSDe_feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0x6A21Beb45CB3d3a7265C97Ebaa0AdC9f39fA4724"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:
@@ -703,6 +712,7 @@ l1:
       address: *earnUSDe_riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x6bc2b37cBd611bC27223E4DBd01F245f6F46d4C1"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       storage:

--- a/configs/lido-earn/mainnet/strategy-arbitrum.yaml
+++ b/configs/lido-earn/mainnet/strategy-arbitrum.yaml
@@ -164,6 +164,7 @@ l1:
       address: *factoryFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xf004f5876D352533fB8b244f1f6227caA8efF867"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -247,6 +248,7 @@ l1:
       address: *consensusFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x50104e78C849B94D9D895e7888Bc464cc1811F89"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -282,6 +284,7 @@ l1:
       address: *depositQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x77da14F966385b19c6e2D99a4448dcFc6FC53985"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -341,6 +344,7 @@ l1:
       address: *feeManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x34BE100C59e7214Ac3382CD5d3E143e8D5107692"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -386,6 +390,7 @@ l1:
       address: *oracleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x03B10BC6ccaa3e7e894f7d0Bac1003BB843F14BF"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -431,6 +436,7 @@ l1:
       address: *redeemQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xFce5f4F214288248F827390223F825dFb8c452be"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -492,6 +498,7 @@ l1:
       address: *riskManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x2eBD4375F9DEd72ed36D49973AeBf182e0e4482c"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -537,6 +544,7 @@ l1:
       address: *shareManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x93Ef6F26BFDCe31CA6D12cCf51e5bE9a95586B08"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -630,6 +638,7 @@ l1:
       address: *subvaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc70e0E18dd7e6239E2808f48Ea9BE4cD77b405af"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -673,6 +682,7 @@ l1:
       address: *verifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc5e76f98C8B6D3f536C2Ea77DE170de34A259341"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -718,6 +728,7 @@ l1:
       address: *vaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xe7AfA247103BDc7dE9054241669741A425Fa5A26"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -844,6 +855,7 @@ l1:
       address: *ERC20VerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xd9d37156529646743B990973a2C3Bad98ceB70a9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -925,6 +937,7 @@ l1:
       address: *vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x6BaDC674878A0C08FF3612dc3E3985225e7F88a5"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1136,6 +1149,7 @@ l1:
       address: *oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x79ced023C6C3fb0015750d86c79F00025437a331"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1173,6 +1187,7 @@ l1:
       address: *shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *tokenizedShareManagerImplementation
+      proxyAdmin: "0x9fE9F1458B940F1d00c23287f699026CBbb7fD00"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1224,6 +1239,7 @@ l1:
       address: *feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0x10fF754b8f4E3ee09cAE82929784cF4BA9e8d228"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1257,6 +1273,7 @@ l1:
       address: *riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x4f3e4F7825Ca6badF221A78b929a7a2248B3f3Bc"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1304,6 +1321,7 @@ l1:
       address: *subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x6d66db9c63D2Dd12d4b7486B9946c9Bcdea493f0"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1321,6 +1339,7 @@ l1:
       address: *verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x5fD2815D1fDcbB838D37B3C31e26756B32dCb369"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:

--- a/configs/lido-earn/mainnet/strategy-ethereum.yaml
+++ b/configs/lido-earn/mainnet/strategy-ethereum.yaml
@@ -229,6 +229,7 @@ l1:
       address: *factoryFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xf004f5876D352533fB8b244f1f6227caA8efF867"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -316,6 +317,7 @@ l1:
       address: *consensusFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x50104e78C849B94D9D895e7888Bc464cc1811F89"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -349,6 +351,7 @@ l1:
       address: *depositQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x77da14F966385b19c6e2D99a4448dcFc6FC53985"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -442,6 +445,7 @@ l1:
       address: *feeManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x34BE100C59e7214Ac3382CD5d3E143e8D5107692"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -491,6 +495,7 @@ l1:
       address: *oracleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x03B10BC6ccaa3e7e894f7d0Bac1003BB843F14BF"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -540,6 +545,7 @@ l1:
       address: *redeemQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xFce5f4F214288248F827390223F825dFb8c452be"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -625,6 +631,7 @@ l1:
       address: *riskManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x2eBD4375F9DEd72ed36D49973AeBf182e0e4482c"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -674,6 +681,7 @@ l1:
       address: *shareManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x93Ef6F26BFDCe31CA6D12cCf51e5bE9a95586B08"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -773,6 +781,7 @@ l1:
       address: *subvaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc70e0E18dd7e6239E2808f48Ea9BE4cD77b405af"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -844,6 +853,7 @@ l1:
       address: *verifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc5e76f98C8B6D3f536C2Ea77DE170de34A259341"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -915,6 +925,7 @@ l1:
       address: *vaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xe7AfA247103BDc7dE9054241669741A425Fa5A26"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1045,6 +1056,7 @@ l1:
       address: *eigenLayerVerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xd9d37156529646743B990973a2C3Bad98ceB70a9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1104,6 +1116,7 @@ l1:
       address: *ERC20VerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x8283eeB88ff09bD49CdCe79887C9b7854eCa0697"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1157,6 +1170,7 @@ l1:
       address: *symbioticVerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xC885556d679e959Da6331F0590D8c8d4a9302848"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1247,6 +1261,7 @@ l1:
       address: *vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x94abDF2b59c6495071f32EB8fb4A0f4d2465A2f2"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1684,6 +1699,7 @@ l1:
       address: *depositQueueETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x0BF025f014C18b1cA3d789b3068FDed929108F37"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1705,6 +1721,7 @@ l1:
       address: *depositQueueWETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x05D96ad320cE2a2a6d3FE0e4eA9A3042D1f40115"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1726,6 +1743,7 @@ l1:
       address: *depositQueueWSTETH
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x80Cf01bBE8C126144EE97b49a17d2b9656186b70"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1747,6 +1765,7 @@ l1:
       address: *depositQueueDVV
       proxyName: TransparentUpgradeableProxy
       implementation: *depositQueueImplementation
+      proxyAdmin: "0x1289B56acBC8a341910027D3EB6E19139fDF3c4b"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1768,6 +1787,7 @@ l1:
       address: *redeemQueueWSTETH
       proxyName: TransparentUpgradeableProxy
       implementation: *redeemQueueImplementation
+      proxyAdmin: "0x1FD8098e9f43D94B3604D1Db4bCAaCBDaa8994a6"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1789,6 +1809,7 @@ l1:
       address: *syncDepositQueueETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xAA3f650a7dEd291bb7ba2Ab5bB9DE7F610999754"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1814,6 +1835,7 @@ l1:
       address: *syncDepositQueueWETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xFB41DC7961a3c26E0CB90d00aFE7EC5a2fE2FCdd"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1839,6 +1861,7 @@ l1:
       address: *syncDepositQueueWSTETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0x19DAd35c42f9AB8AB5628Fd1ed77f6fa1B530A4b"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1864,6 +1887,7 @@ l1:
       address: *syncRedeemQueueWSTETH
       proxyName: TransparentUpgradeableProxy
       implementation: *syncRedeemQueueImplementation
+      proxyAdmin: "0xF635663D4AF08b982185779a9BEaa3eA72c47629"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1891,6 +1915,7 @@ l1:
       address: *syncDepositQueueDVV
       proxyName: TransparentUpgradeableProxy
       implementation: *syncDepositQueueImplementation
+      proxyAdmin: "0xa1480148C57eAE198195b53F5954e5887c1339a8"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1916,6 +1941,7 @@ l1:
       address: *oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x6Ce7C72d54E9BdFb97101bd5C4988B61EB4Fa156"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1989,6 +2015,7 @@ l1:
       address: *shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *tokenizedShareManagerImplementation
+      proxyAdmin: "0x222F62d278D939BDD718569637E32Df45fAd973B"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2040,6 +2067,7 @@ l1:
       address: *feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0x152BB5820Af60De9005453FF58cb1a764bEA2E0F"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2073,6 +2101,7 @@ l1:
       address: *riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0xec949eCEb63F47853551dFAB8BF5BbaC4fc61F86"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2120,6 +2149,7 @@ l1:
       address: *subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x19005b32D422037F2F68D521F6792fA86B5Ba057"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2137,6 +2167,7 @@ l1:
       address: *verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x69C2ca76cd6114C28088Eb3F8eE4a8b872ADefD6"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2170,6 +2201,7 @@ l1:
       address: *subvault1
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0xD0A5294798b9d75062022535683AFA06D13399AF"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2187,6 +2219,7 @@ l1:
       address: *verifier1
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xe895181721DeDC443c55956afdABeE1Cd4356BE4"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2220,6 +2253,7 @@ l1:
       address: *subvault2
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0xB9CD765B44A687aC2047f0B07B198200EDBaa323"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2237,6 +2271,7 @@ l1:
       address: *verifier2
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xAb290b791b1047b23548663d6c6e38cA6174b0Ba"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2270,6 +2305,7 @@ l1:
       address: *subvault3
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x6554efef987ABFE2BA11824f7E5B2AE2547B8E47"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2287,6 +2323,7 @@ l1:
       address: *verifier3
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xabB8a65C206F428B4597d777c861Ffd17a90B881"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2320,6 +2357,7 @@ l1:
       address: *subvault4
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0xBC1f01e06E774CADCE32BFbc901f89F3f99De7C7"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2337,6 +2375,7 @@ l1:
       address: *verifier4
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x4176e5d2324ca00d7e0537a893FE7Fc19faA9A92"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2370,6 +2409,7 @@ l1:
       address: *subvault5
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x2F986591292f8f1bff3C13886F6386410044D8c5"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2387,6 +2427,7 @@ l1:
       address: *verifier5
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0xdC97A9762277C1d69A051A903C0d87584C4629c1"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2420,6 +2461,7 @@ l1:
       address: *subvault6
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x140E4B385ff8943CcEB5eFfA62fd0735b2375FDE"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2437,6 +2479,7 @@ l1:
       address: *verifier6
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x75E6a92C96bE2050918E4279A08d4976d711e12d"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2470,6 +2513,7 @@ l1:
       address: *subvault7
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x677E325F711Dc6AF0720C57acdBfEB4b4891b814"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -2487,6 +2531,7 @@ l1:
       address: *verifier7
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x98C7797B545Cd3F272C9B96eFa0f80C112080f26"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:

--- a/configs/lido-earn/mainnet/strategy-plasma.yaml
+++ b/configs/lido-earn/mainnet/strategy-plasma.yaml
@@ -183,6 +183,7 @@ l1:
       address: *factoryFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xf004f5876D352533fB8b244f1f6227caA8efF867"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -266,6 +267,7 @@ l1:
       address: *consensusFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x50104e78C849B94D9D895e7888Bc464cc1811F89"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -301,6 +303,7 @@ l1:
       address: *depositQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x77da14F966385b19c6e2D99a4448dcFc6FC53985"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -360,6 +363,7 @@ l1:
       address: *feeManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x34BE100C59e7214Ac3382CD5d3E143e8D5107692"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -407,6 +411,7 @@ l1:
       address: *oracleFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x03B10BC6ccaa3e7e894f7d0Bac1003BB843F14BF"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -454,6 +459,7 @@ l1:
       address: *redeemQueueFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xFce5f4F214288248F827390223F825dFb8c452be"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -515,6 +521,7 @@ l1:
       address: *riskManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x2eBD4375F9DEd72ed36D49973AeBf182e0e4482c"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -562,6 +569,7 @@ l1:
       address: *shareManagerFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0x93Ef6F26BFDCe31CA6D12cCf51e5bE9a95586B08"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -657,6 +665,7 @@ l1:
       address: *subvaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc70e0E18dd7e6239E2808f48Ea9BE4cD77b405af"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -722,6 +731,7 @@ l1:
       address: *verifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xc5e76f98C8B6D3f536C2Ea77DE170de34A259341"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -789,6 +799,7 @@ l1:
       address: *vaultFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xe7AfA247103BDc7dE9054241669741A425Fa5A26"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -917,6 +928,7 @@ l1:
       address: *ERC20VerifierFactory
       proxyName: TransparentUpgradeableProxy
       implementation: *factoryImplementation
+      proxyAdmin: "0xd9d37156529646743B990973a2C3Bad98ceB70a9"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -998,6 +1010,7 @@ l1:
       address: *vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0xdf014EE9aF4469BF0fAF0C84927674b70a1673E5"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1211,6 +1224,7 @@ l1:
       address: *oracle
       proxyName: TransparentUpgradeableProxy
       implementation: *oracleImplementation
+      proxyAdmin: "0x79ced023C6C3fb0015750d86c79F00025437a331"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1248,6 +1262,7 @@ l1:
       address: *shareManager
       proxyName: TransparentUpgradeableProxy
       implementation: *tokenizedShareManagerImplementation
+      proxyAdmin: "0x9fE9F1458B940F1d00c23287f699026CBbb7fD00"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1299,6 +1314,7 @@ l1:
       address: *feeManager
       proxyName: TransparentUpgradeableProxy
       implementation: *feeManagerImplementation
+      proxyAdmin: "0x10fF754b8f4E3ee09cAE82929784cF4BA9e8d228"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1332,6 +1348,7 @@ l1:
       address: *riskManager
       proxyName: TransparentUpgradeableProxy
       implementation: *riskManagerImplementation
+      proxyAdmin: "0x4f3e4F7825Ca6badF221A78b929a7a2248B3f3Bc"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1379,6 +1396,7 @@ l1:
       address: *subvault0
       proxyName: TransparentUpgradeableProxy
       implementation: *subvaultImplementation
+      proxyAdmin: "0x402182DF3b12f567C426510b4481Ba75CC0D4899"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:
@@ -1396,6 +1414,7 @@ l1:
       address: *verifier0
       proxyName: TransparentUpgradeableProxy
       implementation: *verifierImplementation
+      proxyAdmin: "0x7AE2f2a4e7711968E02BEF56d8335d3581E5D44e"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:

--- a/configs/lido-multichain/mainnet/adi-bsc.yaml
+++ b/configs/lido-multichain/mainnet/adi-bsc.yaml
@@ -78,6 +78,7 @@ l1:
       address: *ethCCC
       proxyName: TransparentUpgradeableProxy
       implementation: *ethCCCImp
+      proxyAdmin: "0xADD673dC6A655AFD6f38fB88301028fA31A6fDeE"
       proxyAdminOwner: *ethDaoAgent
       proxyChecks: {}
       checks:
@@ -252,6 +253,7 @@ l2:
       address: *bnbCCC
       proxyName: TransparentUpgradeableProxy
       implementation: *bnbCCCImp
+      proxyAdmin: "0x29E6817db339795766244B96aEf5Dc534a98518d"
       proxyAdminOwner: *bnbCCE
       proxyChecks: {}
       checks:

--- a/configs/lido-multichain/testnet/adi-bsc.yaml
+++ b/configs/lido-multichain/testnet/adi-bsc.yaml
@@ -67,6 +67,7 @@ l1:
       address: *sepCCC
       proxyName: TransparentUpgradeableProxy
       implementation: *sepCCCImp
+      proxyAdmin: "0x7BE89331452883D335C2556d1863CD2925E76afc"
       proxyAdminOwner: *sepDaoAgent
       proxyChecks: {}
       checks:
@@ -291,6 +292,7 @@ l2:
       address: *bnbtCCC
       proxyName: TransparentUpgradeableProxy
       implementation: *bnbtCCCImp
+      proxyAdmin: "0x490E441352635aacA64224c8205636FD9d2e3362"
       proxyAdminOwner: *bnbtCCE
       proxyChecks: {}
       checks:

--- a/configs/mellow/mainnet/dvv.yaml
+++ b/configs/mellow/mainnet/dvv.yaml
@@ -65,6 +65,7 @@ l1:
       address: *vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: "0x8E6C80c41450D3fA7B1Fd0196676b99Bfb34bF48"
       proxyAdminOwner: *proxyAdmin
       proxyChecks: {}
       checks:

--- a/docs/abi-and-proxies.md
+++ b/docs/abi-and-proxies.md
@@ -29,8 +29,8 @@ For each declared `implementation`, state-mate reads the EIP-1967 implementation
 
 An entry without `implementation` must have an empty EIP-1967 implementation slot. This prevents a proxy from being described as a regular contract and checked with the wrong ABI. An unreadable implementation fails the check; `--skip-implementation-check` is the explicit bypass.
 
-## ProxyAdmin ownership
+## ProxyAdmin verification
 
-A declared `proxyAdminOwner` check is independent of the implementation bypass. state-mate reads the EIP-1967 admin slot, calls `owner()` on that address, and compares the result with the config.
+The `proxyAdmin` and `proxyAdminOwner` checks are independent of the implementation bypass and share one read of the EIP-1967 admin slot. `proxyAdmin` pins the contract the slot holds; `proxyAdminOwner` calls `owner()` on that contract and compares the answer. They answer different questions — an unexpected ProxyAdmin owned by the expected owner passes `proxyAdminOwner` alone — so pin both when the admin contract itself matters.
 
-The ProxyAdmin address needs no ABI entry. Use a `storage` check when the config must also pin the admin address itself. An admin that does not implement `owner()`, such as a Safe, fails this check and should be asserted through `storage` instead.
+Neither field needs an ABI entry. An admin that does not implement `owner()`, such as a Safe, fails `proxyAdminOwner` and should be pinned with `proxyAdmin` instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ parameters:
   - &vault "0x0000000000000000000000000000000000000001"
   - &vaultImplementation "0x0000000000000000000000000000000000000002"
   - &admin "0x0000000000000000000000000000000000000003"
+  - &vaultProxyAdmin "0x0000000000000000000000000000000000000004"
 
 roles:
   - &DEFAULT_ADMIN_ROLE "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -31,6 +32,7 @@ l1:
       address: *vault
       proxyName: TransparentUpgradeableProxy
       implementation: *vaultImplementation
+      proxyAdmin: *vaultProxyAdmin
       proxyAdminOwner: *admin
       checks:
         owner: *admin
@@ -65,6 +67,7 @@ The addresses under `deployed` determine which ABIs state-mate stores. Include i
 | `ozAcl`                | Exact role counts and members for enumerable OpenZeppelin access control                |
 | `ozNonEnumerableAcl`   | Declared memberships across the roles and holders listed in the config                  |
 | `implementation`       | The implementation address reported by the chain                                        |
+| `proxyAdmin`           | The contract held in the EIP-1967 admin slot                                            |
 | `proxyAdminOwner`      | The owner of the `ProxyAdmin` in the EIP-1967 admin slot                                |
 
 Every `view` and `pure` function in the selected ABI must appear in `checks`. A `null` result marks a function as deliberately skipped and reports it in the totals.

--- a/schemas/main-schema.json
+++ b/schemas/main-schema.json
@@ -1498,6 +1498,11 @@
                       "pattern": "^(0x[a-fA-F0-9]{40}|0x[a-fA-F0-9]{64}|.+)$",
                       "type": "string"
                     },
+                    "proxyAdmin": {
+                      "format": "ethereum-string",
+                      "pattern": "^(0x[a-fA-F0-9]{40}|0x[a-fA-F0-9]{64}|.+)$",
+                      "type": "string"
+                    },
                     "proxyAdminOwner": {
                       "format": "ethereum-string",
                       "pattern": "^(0x[a-fA-F0-9]{40}|0x[a-fA-F0-9]{64}|.+)$",
@@ -3681,6 +3686,11 @@
                       "type": "string"
                     },
                     "implementation": {
+                      "format": "ethereum-string",
+                      "pattern": "^(0x[a-fA-F0-9]{40}|0x[a-fA-F0-9]{64}|.+)$",
+                      "type": "string"
+                    },
+                    "proxyAdmin": {
                       "format": "ethereum-string",
                       "pattern": "^(0x[a-fA-F0-9]{40}|0x[a-fA-F0-9]{64}|.+)$",
                       "type": "string"

--- a/src/section-validators/contract.ts
+++ b/src/section-validators/contract.ts
@@ -16,7 +16,7 @@ import {
   setErrorContext,
 } from "./base";
 import { ChecksSectionValidator } from "./checks";
-import { checkImplementation, checkProxyAdminOwner } from "./implementation";
+import { checkImplementation, checkProxyAdmin } from "./implementation";
 import { ImplementationChecksSectionValidator } from "./implementation-checks";
 import { OzAclSectionValidator } from "./oz-acl";
 import { OzNonEnumerableAclSectionValidator } from "./oz-non-enumerable-acl";
@@ -91,7 +91,7 @@ export class ContractSectionValidator {
     const basePath = `${sectionTitle}/${contractAlias}`;
 
     await checkImplementation(this.provider, contractEntry);
-    await checkProxyAdminOwner(this.provider, contractEntry);
+    await checkProxyAdmin(this.provider, contractEntry);
 
     if (needCheck(CheckLevel.checksType, EntryField.checks)) {
       logHeader2(`${basePath}/${EntryField.checks}`);

--- a/src/section-validators/implementation.ts
+++ b/src/section-validators/implementation.ts
@@ -208,33 +208,64 @@ export async function checkImplementation(provider: JsonRpcProvider, contractEnt
   logHandle.success(actual);
 }
 
-/**
- * Verifies who owns the ProxyAdmin a transparent proxy delegates upgrades to. The ProxyAdmin
- * address itself is a `storage:` check away, but its owner is one hop further, and that owner is
- * what actually controls the upgrade. Opt-in per entry, so no bypass flag.
- */
-export async function checkProxyAdminOwner(provider: JsonRpcProvider, contractEntry: ContractEntry): Promise<void> {
-  if (!isTypeOfTB(contractEntry, ProxyContractEntryTB) || !contractEntry.proxyAdminOwner) return;
-
-  const { address, proxyAdminOwner: expected } = contractEntry;
-  setErrorContext({ checksType: "proxyAdminOwner", method: "proxyAdminOwner" });
+/** Each declared field is a check of its own: one log line, one counter, at most one error. */
+function openAdminCheck(label: string): { fail: (message: string) => void; pass: (message: string) => void } {
+  setErrorContext({ checksType: label, method: label });
   incChecks();
-  const logHandle = new LogCommand("proxyAdminOwner");
+  const logHandle = new LogCommand(label);
+  return {
+    fail(message: string) {
+      logHandle.failure(message);
+      incErrors(message);
+    },
+    pass(message: string) {
+      logHandle.success(message);
+    },
+  };
+}
+
+/**
+ * Verifies the ProxyAdmin a transparent proxy delegates upgrades to. `proxyAdmin:` pins the
+ * contract the EIP-1967 admin slot holds, `proxyAdminOwner:` pins the address that controls it one
+ * hop further. Owning the expected owner says nothing about which contract holds the upgrade
+ * rights, so the two answer different questions. Opt-in per entry, so no bypass flag.
+ */
+export async function checkProxyAdmin(provider: JsonRpcProvider, contractEntry: ContractEntry): Promise<void> {
+  if (!isTypeOfTB(contractEntry, ProxyContractEntryTB)) return;
+
+  const { address, proxyAdmin: expectedAdmin, proxyAdminOwner: expectedOwner } = contractEntry;
+  if (!expectedAdmin && !expectedOwner) return;
 
   const adminSlot = await readSlotWord(provider, address, EIP1967_ADMIN_SLOT);
   // An unanswered read proves nothing about the proxy: a throttled or failing provider must not
   // be reported as a proxy that keeps no admin
-  if (adminSlot.failed) {
-    const message = `the admin slot of ${address} could not be read, so nothing was verified; retry`;
-    logHandle.failure(message);
-    incErrors(message);
+  const unreadable = adminSlot.failed
+    ? `the admin slot of ${address} could not be read, so nothing was verified; retry`
+    : undefined;
+  const admin = addressFromWord(adminSlot.word);
+
+  if (expectedAdmin) {
+    const check = openAdminCheck("proxyAdmin");
+    if (unreadable) {
+      check.fail(unreadable);
+    } else if (!admin) {
+      check.fail(`${address} keeps no admin in the EIP-1967 slot, while the config expects ${expectedAdmin}`);
+    } else if (admin.toLowerCase() === expectedAdmin.toLowerCase()) {
+      check.pass(admin);
+    } else {
+      check.fail(`${address} is administered by ${admin}, while the config expects ${expectedAdmin}`);
+    }
+  }
+
+  if (!expectedOwner) return;
+
+  const check = openAdminCheck("proxyAdminOwner");
+  if (unreadable) {
+    check.fail(unreadable);
     return;
   }
-  const admin = addressFromWord(adminSlot.word);
   if (!admin) {
-    const message = `${address} keeps no admin in the EIP-1967 slot, so it has no ProxyAdmin to own`;
-    logHandle.failure(message);
-    incErrors(message);
+    check.fail(`${address} keeps no admin in the EIP-1967 slot, so it has no ProxyAdmin to own`);
     return;
   }
 
@@ -243,20 +274,17 @@ export async function checkProxyAdminOwner(provider: JsonRpcProvider, contractEn
   const ownerWord = await callWord(provider, admin, OWNER_SELECTOR);
   const owner = /^0x0{64}$/.test(ownerWord ?? "") ? ZERO_ADDRESS : addressFromWord(ownerWord);
   if (!owner) {
-    const message =
+    check.fail(
       `the admin of ${address}, ${admin}, does not answer owner(). ` +
-      `Assert the admin address itself with a ${chalk.yellow("storage:")} check on the EIP-1967 admin slot`;
-    logHandle.failure(message);
-    incErrors(message);
+        `Assert the admin address itself with ${chalk.yellow("proxyAdmin:")}`,
+    );
     return;
   }
 
-  if (owner.toLowerCase() !== expected.toLowerCase()) {
-    const message = `${admin} administers ${address} and is owned by ${owner}, while the config expects ${expected}`;
-    logHandle.failure(message);
-    incErrors(message);
+  if (owner.toLowerCase() !== expectedOwner.toLowerCase()) {
+    check.fail(`${admin} administers ${address} and is owned by ${owner}, while the config expects ${expectedOwner}`);
     return;
   }
 
-  logHandle.success(`${owner} owns ${admin}`);
+  check.pass(`${owner} owns ${admin}`);
 }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -181,6 +181,7 @@ export const ProxyContractEntryTB = Type.Readonly(
       ...RegularContractEntryTB.properties,
       proxyName: Type.String(),
       implementation: Type.Optional(EthereumStringTB),
+      proxyAdmin: Type.Optional(EthereumStringTB),
       proxyAdminOwner: Type.Optional(EthereumStringTB),
       proxyChecks: Type.Optional(Type.Union([ProxyChecksTB, Sr2ProxyChecksTB, AragonProxyChecksTB])),
       implementationChecks: ImplementationChecksTB,

--- a/tests/implementation.test.ts
+++ b/tests/implementation.test.ts
@@ -5,7 +5,7 @@ import type { JsonRpcProvider } from "ethers";
 
 import { context, resetStats, stats } from "../src/context";
 import { resetContractCounters } from "../src/section-validators/base";
-import { checkImplementation, checkProxyAdminOwner } from "../src/section-validators/implementation";
+import { checkImplementation, checkProxyAdmin } from "../src/section-validators/implementation";
 import type { ContractEntry } from "../src/typebox";
 
 const PROXY_ADDRESS = "0xAaAaAAaaAaAAAaaAAaAaaaAAaAAAaaaAaaaaaaa1";
@@ -13,6 +13,7 @@ const IMPL_ADDRESS = "0xBbbBBBbbbBBbbbBbbBbbbbBBbBBbbBbBbbbbbbb2";
 const OTHER_IMPL_ADDRESS = "0xcCCcccCcCCcCcCCCcCcccCcCcCcCcCCcCcccCcC3";
 const PROXY_ADMIN_ADDRESS = "0xDdDDDddDdDddDDddDDddDDDDdDdDDdDDdDDDDDD4";
 const OWNER_ADDRESS = "0xEeeEEEeeeEEEeeeEEEeeeeEeeeeEEEEeeEEeEeE5";
+const OTHER_ADMIN_ADDRESS = "0x9999999999999999999999999999999999999999";
 const EIP1967_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 const ADMIN_SLOT = "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
 const SAFE_SLOT = "0x0";
@@ -75,6 +76,10 @@ function safePinnedEntry(singleton: string): ContractEntry {
 
 function adminOwnerEntry(proxyAdminOwner?: string): ContractEntry {
   return { ...proxyEntry(IMPL_ADDRESS), proxyAdminOwner } as ContractEntry;
+}
+
+function adminEntry(fields: { proxyAdmin?: string; proxyAdminOwner?: string }): ContractEntry {
+  return { ...proxyEntry(IMPL_ADDRESS), ...fields } as ContractEntry;
 }
 
 const originalWrite = process.stdout.write.bind(process.stdout);
@@ -386,14 +391,14 @@ describe("checkImplementation", () => {
   });
 });
 
-describe("checkProxyAdminOwner", () => {
+describe("checkProxyAdmin", () => {
   it("passes when the ProxyAdmin behind the proxy is owned by the expected address", async () => {
     const { provider, reads } = stubProvider({
       calls: { [PROXY_ADMIN_ADDRESS.toLowerCase()]: word(OWNER_ADDRESS) },
       slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) },
     });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.errors, 0);
     assert.equal(stats.totalChecks, 1);
@@ -406,7 +411,7 @@ describe("checkProxyAdminOwner", () => {
       slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) },
     });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.errors, 1);
     const { message } = stats.errorDetails[0];
@@ -418,7 +423,7 @@ describe("checkProxyAdminOwner", () => {
   it("fails when the proxy keeps no admin in the EIP-1967 slot", async () => {
     const { provider } = stubProvider({});
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.errors, 1);
     assert.match(stats.errorDetails[0].message, /no admin in the EIP-1967 slot/);
@@ -427,7 +432,7 @@ describe("checkProxyAdminOwner", () => {
   it("separates an unreadable admin slot from a proxy that keeps no admin", async () => {
     const { provider } = stubProvider({ slotErrors: { [ADMIN_SLOT]: new Error("missing revert data") } });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.errors, 1);
     const { message } = stats.errorDetails[0];
@@ -435,18 +440,18 @@ describe("checkProxyAdminOwner", () => {
     assert.doesNotMatch(message, /no admin in the EIP-1967 slot/);
   });
 
-  it("points at a storage check when the admin does not answer owner()", async () => {
+  it("points at the admin pin when the admin does not answer owner()", async () => {
     const { provider } = stubProvider({
       calls: { [PROXY_ADMIN_ADDRESS.toLowerCase()]: new Error("execution reverted") },
       slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) },
     });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.errors, 1);
     const { message } = stats.errorDetails[0];
     assert.match(message, /does not answer owner\(\)/);
-    assert.match(message, /storage:/);
+    assert.match(message, /proxyAdmin:/);
   });
 
   it("accepts a renounced ProxyAdmin when the config expects the zero owner", async () => {
@@ -455,7 +460,7 @@ describe("checkProxyAdminOwner", () => {
       slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) },
     });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(`0x${"0".repeat(40)}`));
+    await checkProxyAdmin(provider, adminOwnerEntry(`0x${"0".repeat(40)}`));
 
     assert.equal(stats.errors, 0);
   });
@@ -466,7 +471,7 @@ describe("checkProxyAdminOwner", () => {
       slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) },
     });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.errors, 1);
     const { message } = stats.errorDetails[0];
@@ -481,7 +486,7 @@ describe("checkProxyAdminOwner", () => {
     });
     context.checkOnly = { section: "l1", checksType: "checks" };
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry(OWNER_ADDRESS));
+    await checkProxyAdmin(provider, adminOwnerEntry(OWNER_ADDRESS));
 
     assert.equal(stats.totalChecks, 1);
     assert.equal(stats.errors, 0);
@@ -490,9 +495,75 @@ describe("checkProxyAdminOwner", () => {
   it("reads nothing for an entry without the field", async () => {
     const { provider, reads } = stubProvider({ slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) } });
 
-    await checkProxyAdminOwner(provider, adminOwnerEntry());
+    await checkProxyAdmin(provider, adminOwnerEntry());
 
     assert.deepEqual(reads, []);
     assert.equal(stats.totalChecks, 0);
+  });
+
+  it("passes when the EIP-1967 admin slot holds the declared ProxyAdmin", async () => {
+    const { provider, reads } = stubProvider({ slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) } });
+
+    await checkProxyAdmin(provider, adminEntry({ proxyAdmin: PROXY_ADMIN_ADDRESS }));
+
+    assert.equal(stats.errors, 0);
+    assert.equal(stats.totalChecks, 1);
+    // no owner() call: pinning the admin address asks nothing about who controls it
+    assert.deepEqual(reads, [`slot:${ADMIN_SLOT}`]);
+  });
+
+  it("names the administering contract and the expectation when they differ", async () => {
+    const { provider } = stubProvider({ slots: { [ADMIN_SLOT]: word(OTHER_ADMIN_ADDRESS) } });
+
+    await checkProxyAdmin(provider, adminEntry({ proxyAdmin: PROXY_ADMIN_ADDRESS }));
+
+    assert.equal(stats.errors, 1);
+    const { message } = stats.errorDetails[0];
+    assert.match(message, new RegExp(OTHER_ADMIN_ADDRESS, "i"));
+    assert.match(message, new RegExp(PROXY_ADMIN_ADDRESS, "i"));
+  });
+
+  it("fails the admin pin when the slot holds no address", async () => {
+    const { provider } = stubProvider({});
+
+    await checkProxyAdmin(provider, adminEntry({ proxyAdmin: PROXY_ADMIN_ADDRESS }));
+
+    assert.equal(stats.errors, 1);
+    assert.match(stats.errorDetails[0].message, /no admin in the EIP-1967 slot/);
+  });
+
+  it("catches an unexpected ProxyAdmin that answers the expected owner", async () => {
+    const { provider } = stubProvider({
+      calls: { [OTHER_ADMIN_ADDRESS.toLowerCase()]: word(OWNER_ADDRESS) },
+      slots: { [ADMIN_SLOT]: word(OTHER_ADMIN_ADDRESS) },
+    });
+
+    await checkProxyAdmin(provider, adminEntry({ proxyAdmin: PROXY_ADMIN_ADDRESS, proxyAdminOwner: OWNER_ADDRESS }));
+
+    assert.equal(stats.totalChecks, 2);
+    assert.equal(stats.errors, 1);
+    assert.equal(stats.errorDetails[0].checksType, "proxyAdmin");
+  });
+
+  it("reads the admin slot once for both fields", async () => {
+    const { provider, reads } = stubProvider({
+      calls: { [PROXY_ADMIN_ADDRESS.toLowerCase()]: word(OWNER_ADDRESS) },
+      slots: { [ADMIN_SLOT]: word(PROXY_ADMIN_ADDRESS) },
+    });
+
+    await checkProxyAdmin(provider, adminEntry({ proxyAdmin: PROXY_ADMIN_ADDRESS, proxyAdminOwner: OWNER_ADDRESS }));
+
+    assert.equal(stats.totalChecks, 2);
+    assert.equal(stats.errors, 0);
+    assert.deepEqual(reads, [`slot:${ADMIN_SLOT}`, `call:${PROXY_ADMIN_ADDRESS.toLowerCase()}`]);
+  });
+
+  it("reports an unreadable admin slot against every declared field", async () => {
+    const { provider } = stubProvider({ slotErrors: { [ADMIN_SLOT]: new Error("missing revert data") } });
+
+    await checkProxyAdmin(provider, adminEntry({ proxyAdmin: PROXY_ADMIN_ADDRESS, proxyAdminOwner: OWNER_ADDRESS }));
+
+    assert.equal(stats.errors, 2);
+    for (const detail of stats.errorDetails) assert.match(detail.message, /could not be read/);
   });
 });


### PR DESCRIPTION
Stacked on `docs/refresh-readme`.

`proxyAdminOwner:` verifies who owns whatever contract sits in the EIP-1967 admin slot, never which contract that is. Commit e4b786c dropped 115 `storage:` pins of per-proxy ProxyAdmin addresses from the earn configs and replaced them with a single owner expectation, so an unexpected ProxyAdmin owned by the expected owner now passes.

## Changes

**Schema and checker.** `proxyAdmin:` is a new optional field on proxy entries, pinning the contract the admin slot holds. `checkProxyAdminOwner` becomes `checkProxyAdmin`: it reads the admin slot once and reports each declared field as its own check, with its own log line, counter and error. The `does not answer owner()` hint now points at `proxyAdmin:` instead of a hand-written `storage:` check.

**Configs.** 210 proxy entries across 11 files get `proxyAdmin:` with the address the chain actually holds. For 206 of them the admin equals `CREATE(proxy, nonce 1)`, which is what an OZ v5 `TransparentUpgradeableProxy` deploys for itself; the 4 aDI entries keep an external shared ProxyAdmin and were read from the slot. Every pin was verified against the chain after insertion: 210 matched, 0 mismatched. Neither field needs a `ProxyAdmin` contract entry or its ABI, so the store is untouched.

**Tests.** Six new cases. The one that matters: an unexpected ProxyAdmin that answers the expected owner now produces an error instead of two silent passes.

## Verification

`yarn lint`, `yarn typecheck`, `yarn format` clean, `yarn test` 104/104, `schemas/` regenerated from typebox. Full config runs are left to CI.
