### PR TITLE
chore: bump version to 1.0.0 to match latest release

### DIFF
--- a/configs/lido-earn/mainnet/earneth-vaults.yaml
+++ b/configs/lido-earn/mainnet/earneth-vaults.yaml
@@ -596,7 +596,7 @@ l1:
       checks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ETH
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -605,7 +605,7 @@ l1:
       implementationChecks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -654,7 +654,7 @@ l1:
       checks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *weth
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -663,7 +663,7 @@ l1:
       implementationChecks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -712,7 +712,7 @@ l1:
       checks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *wsteth
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -721,7 +721,7 @@ l1:
       implementationChecks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -743,7 +743,7 @@ l1:
       checks:
         asset: *wsteth
         batchAt:
-        canBeRemoved: false
+        canBeRemoved:
         claimableOf:
         # getState: [batchIterator, batchCount, totalDemandAssets, totalPendingShares]
         getState:
@@ -752,7 +752,7 @@ l1:
       implementationChecks:
         asset: *ZERO_ADDRESS
         batchAt:
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
         getState:
         requestsOf:
@@ -773,7 +773,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *wsteth
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -784,7 +784,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]
@@ -812,7 +812,7 @@ l1:
         vault: *vault
       implementationChecks:
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
         requestOf:
         unclaimedRequests: 0
@@ -833,7 +833,7 @@ l1:
       checks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ggv
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -842,7 +842,7 @@ l1:
       implementationChecks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -870,7 +870,7 @@ l1:
         vault: *vault
       implementationChecks:
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
         requestOf:
         unclaimedRequests: 0
@@ -891,7 +891,7 @@ l1:
       checks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *streth
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -900,7 +900,7 @@ l1:
       implementationChecks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -928,7 +928,7 @@ l1:
         vault: *vault
       implementationChecks:
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
         requestOf:
         unclaimedRequests: 0
@@ -949,7 +949,7 @@ l1:
       checks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *dVstETH
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"
@@ -958,7 +958,7 @@ l1:
       implementationChecks:
         SET_SYNC_DEPOSIT_PARAMS_ROLE: *SET_SYNC_DEPOSIT_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claim:
         claimableOf:
         name: "SyncDepositQueue"

--- a/configs/lido-earn/mainnet/earnusd-vaults-ethereum.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-ethereum.yaml
@@ -766,7 +766,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *usdc
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -777,7 +777,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]
@@ -1557,7 +1557,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *usdc
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -1568,7 +1568,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]
@@ -1621,7 +1621,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *usdt
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -1632,7 +1632,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]
@@ -2372,7 +2372,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *usdc
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -2383,7 +2383,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]
@@ -2436,7 +2436,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *usdt
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -2447,7 +2447,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]

--- a/configs/lido-earn/mainnet/strategy-arbitrum.yaml
+++ b/configs/lido-earn/mainnet/strategy-arbitrum.yaml
@@ -327,7 +327,7 @@ l1:
       checks:
         ORDER_TYPEHASH: "0xb367c53189b3057a91923801116b5f9c4e7211a314d1961f94770747512a1b68"
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf: # this queue doesn't have claimableOf shares
         consensus: *ZERO_ADDRESS
         consensusFactory: *consensusFactory
@@ -479,7 +479,7 @@ l1:
       checks:
         ORDER_TYPEHASH: "0xb367c53189b3057a91923801116b5f9c4e7211a314d1961f94770747512a1b68"
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
           - args: [*ZERO_ADDRESS]
             result: 0

--- a/configs/lido-earn/mainnet/strategy-ethereum.yaml
+++ b/configs/lido-earn/mainnet/strategy-ethereum.yaml
@@ -428,7 +428,7 @@ l1:
       checks:
         ORDER_TYPEHASH: "0xb367c53189b3057a91923801116b5f9c4e7211a314d1961f94770747512a1b68"
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf: # this queue doesn't have claimableOf shares
         consensus: *ZERO_ADDRESS
         consensusFactory: *consensusFactory
@@ -612,7 +612,7 @@ l1:
       checks:
         ORDER_TYPEHASH: "0xb367c53189b3057a91923801116b5f9c4e7211a314d1961f94770747512a1b68"
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
           - args: [*ZERO_ADDRESS]
             result: 0
@@ -1800,7 +1800,7 @@ l1:
       implementationChecks:
         asset: *ZERO_ADDRESS
         batchAt:
-        canBeRemoved: true
+        canBeRemoved:
         getState:
         requestsOf:
         vault: *ZERO_ADDRESS
@@ -1893,7 +1893,7 @@ l1:
       checks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *lidoWsteth
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         # [usage, remainingDailyLimit] — both move with every redeem
@@ -1904,7 +1904,7 @@ l1:
       implementationChecks:
         SET_SYNC_REDEEM_PARAMS_ROLE: *SET_SYNC_REDEEM_PARAMS_ROLE
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         getLiquidAssets:
         name: "SyncRedeemQueue"
         remainingDailyLimit: [0, 0]

--- a/configs/lido-earn/mainnet/strategy-plasma.yaml
+++ b/configs/lido-earn/mainnet/strategy-plasma.yaml
@@ -346,7 +346,7 @@ l1:
       checks:
         ORDER_TYPEHASH: "0xb367c53189b3057a91923801116b5f9c4e7211a314d1961f94770747512a1b68"
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf: # this queue doesn't have claimableOf shares
         consensus: *ZERO_ADDRESS
         consensusFactory: *consensusFactory
@@ -502,7 +502,7 @@ l1:
       checks:
         ORDER_TYPEHASH: "0xb367c53189b3057a91923801116b5f9c4e7211a314d1961f94770747512a1b68"
         asset: *ZERO_ADDRESS
-        canBeRemoved: true
+        canBeRemoved:
         claimableOf:
           - args: [*ZERO_ADDRESS]
             result: 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "state-mate",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Ethereum + L2s smart contract state checker",
   "main": "state-checker.ts",
   "license": "MIT",


### PR DESCRIPTION
package.json still carried 0.1.0 while the latest release is v1.0.0. Aligns the version field with the release tag.