### PR TITLE
Fix: keep a no-change ABI rebuild from rewriting the store

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,12 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           if ! git diff --exit-code -- ${{ matrix.config }}; then
+            # the store is gzipped, so show the content diff the binary one cannot
+            for f in $(git diff --name-only -- ${{ matrix.config }}); do
+              case "$f" in
+                *.json.gz) diff <(git show "HEAD:$f" | gunzip) <(gunzip -c "$f") || true ;;
+              esac
+            done
             echo "Error: the committed ABI store differs from what the explorer serves."
             exit 1
           fi

--- a/src/abi-provider.ts
+++ b/src/abi-provider.ts
@@ -247,6 +247,15 @@ export function pruneAbiStores(): void {
   }
 }
 
+/** An unreadable store is not a match: the write below replaces it, as it always has. */
+function _storeHolds(storePath: string, serialized: string): boolean {
+  try {
+    return zlib.gunzipSync(fs.readFileSync(storePath)).toString("utf8") === serialized;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Flushes all pending ABI updates to disk.
  * This should be called after all ABI updates are complete to write once.
@@ -256,7 +265,15 @@ export function flushAbiUpdates(): void {
 
   const outputPath = getConsolidatedAbiPath();
   try {
-    const compressed = zlib.gzipSync(JSON.stringify(pendingAbiUpdates, null, 2));
+    const serialized = JSON.stringify(pendingAbiUpdates, null, 2);
+    // gzip bytes are not portable: zlib emits different streams per platform build for the same
+    // input, so rewriting an unchanged store breaks any byte-level comparison of the file
+    if (fs.existsSync(outputPath) && _storeHolds(outputPath, serialized)) {
+      consolidatedAbisCache = pendingAbiUpdates;
+      pendingAbiUpdates = null;
+      return;
+    }
+    const compressed = zlib.gzipSync(serialized);
     // temp + rename keeps the store whole if the process dies mid-write
     fs.writeFileSync(`${outputPath}.tmp`, compressed);
     fs.renameSync(`${outputPath}.tmp`, outputPath);

--- a/tests/abi-provider.test.ts
+++ b/tests/abi-provider.test.ts
@@ -755,6 +755,27 @@ describe("checkAllAbi + flushAbiUpdates", () => {
     assert.deepEqual(store[scopedKey(ETH_CHAIN_ID, IMPL_ADDRESS)], { name: "Lido", abi: LIDO_ABI });
   });
 
+  // gzip bytes are not portable across platform builds of zlib, so a store written on another
+  // machine must survive a no-change rebuild byte-identical: CI compares the compressed file
+  it("leaves the store bytes untouched when a rebuild changes nothing", async () => {
+    const directory = setupConfigDirectory();
+    const seeded = zlib.gzipSync(
+      JSON.stringify(
+        { [scopedKey(ETH_CHAIN_ID, PROXY_ADDRESS)]: { name: "OssifiableProxy", abi: PROXY_ABI } },
+        null,
+        2,
+      ),
+      { level: 1 },
+    );
+    fs.writeFileSync(path.join(directory, "abis.json.gz"), seeded);
+    context.updateAbi = true;
+
+    await checkAllAbi(ETH_CHAIN_ID, proxyInfo);
+    flushAbiUpdates();
+
+    assert.deepEqual(fs.readFileSync(path.join(directory, "abis.json.gz")), seeded);
+  });
+
   it("re-downloads an existing entry with --update-abi", async () => {
     const directory = setupConfigDirectory({
       [scopedKey(ETH_CHAIN_ID, PROXY_ADDRESS)]: { name: "OssifiableProxy", abi: PROXY_ABI },


### PR DESCRIPTION
## Problem

The nightly ABI provenance check (added in 5459133) has failed on all nine configs every night since its first run. The step compares the compressed `abis.json.gz` byte-for-byte via `git diff`, and `--update-abi` rewrites the store unconditionally.

The stores were committed from an arm64 machine. The CI runner is linux x64, and Node's bundled zlib-ng picks different SIMD code paths per platform build, producing a different deflate stream for identical input. Verified directly: the same store JSON gzipped under `node:24.19.0` on linux/amd64 yields a file of the same size with different bytes, while an arm64 rebuild reproduces the committed file exactly. The store content never actually drifted; a local `--update-abi` run of `configs/defiwrapper/mainnet` on `main` rewrote the committed file byte-identically.

The rate-limit refusals visible in the nightly logs are unrelated: a refused address keeps its stored entry as-is and cannot change the bytes.

## Fix

- `flushAbiUpdates` now compares the serialized store against the decompressed content of the existing file and skips the write when nothing changed, so a no-change rebuild leaves the committed bytes alone whatever platform wrote them. An unreadable store file is not a match and gets replaced by the write, as before.
- When the provenance check does fail, the step now prints the decompressed JSON diff next to the binary notice, so the nightly names the drifted entries instead of `Binary files differ`.

A genuine drift still writes the store and fails the nightly; only the false positive is gone.

## Testing

New unit test seeds a store with a different gzip stream of identical content (`level: 1`) and asserts a `--update-abi` rebuild leaves the file byte-identical. Full suite: 211 pass.