### PR TITLE
fix: resolve EIP-1167 implementations

### DIFF
--- a/src/section-validators/implementation.ts
+++ b/src/section-validators/implementation.ts
@@ -23,6 +23,7 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 // slot holds an ordinary variable, and an address-shaped one would fake a mismatch
 const SAFE_SINGLETON_SLOT = "0x0";
 const SAFE_PROXY_NAMES = new Set(["SafeProxy", "GnosisSafeProxy"]);
+const EIP1167_RUNTIME = /^0x363d3d373d3d3d363d73([0-9a-fA-F]{40})5af43d82803e903d91602b57fd5bf3$/;
 
 const BYPASS_HINT = `pass ${chalk.yellow("--skip-implementation-check")} to skip this check`;
 
@@ -64,6 +65,15 @@ async function callAsAddress(
   selector: string,
 ): Promise<string | undefined> {
   return addressFromWord(await callWord(provider, address, selector));
+}
+
+async function readEip1167Implementation(provider: JsonRpcProvider, address: string): Promise<string | undefined> {
+  try {
+    const match = EIP1167_RUNTIME.exec(await provider.getCode(address));
+    return match ? getAddress(`0x${match[1]}`) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Numeric comparison, so hex case, word width and leading zeros do not matter. */
@@ -189,6 +199,7 @@ export async function checkImplementation(provider: JsonRpcProvider, contractEnt
     // The config declares this one a proxy, so the riskier reads are safe to try
     actual = slotImplementation ?? (await callAsAddress(provider, address, IMPLEMENTATION_SELECTOR));
     actual ??= await callAsAddress(provider, address, PROXY_GET_IMPLEMENTATION_SELECTOR);
+    actual ??= await readEip1167Implementation(provider, address);
   }
 
   if (!actual) {

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -331,7 +331,11 @@ async function main() {
   // No prune here: a single-file run has walked only its own addresses, and sweeping the shared
   // store now would drop the sibling configs' ABIs
   await runConfig();
-  if (stats.errors) process.exit(stats.errors);
+  if (stats.errors) process.exit(checkFailureExitCode(stats.errors));
+}
+
+export function checkFailureExitCode(errors: number): 0 | 1 {
+  return errors === 0 ? 0 : 1;
 }
 
 async function runConfig() {

--- a/tests/exit-code.test.ts
+++ b/tests/exit-code.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { checkFailureExitCode } from "../src/state-mate";
+
+describe("check failure exit code", () => {
+  it("does not wrap large error counts into a successful process status", () => {
+    assert.equal(checkFailureExitCode(0), 0);
+    assert.equal(checkFailureExitCode(1), 1);
+    assert.equal(checkFailureExitCode(141), 1);
+    assert.equal(checkFailureExitCode(256), 1);
+  });
+});

--- a/tests/implementation.test.ts
+++ b/tests/implementation.test.ts
@@ -26,6 +26,7 @@ function word(address: string): string {
 type ProviderStub = {
   callResult?: Error | string;
   calls?: Record<string, Error | string>;
+  code?: string;
   selectors?: Record<string, Error | string>;
   slotErrors?: Record<string, Error>;
   slots?: Record<string, string>;
@@ -46,6 +47,10 @@ function stubProvider(stub: ProviderStub): { provider: JsonRpcProvider; reads: s
       const failure = stub.slotErrors?.[slot];
       if (failure) throw failure;
       return stub.slots?.[slot] ?? ZERO_WORD;
+    },
+    async getCode(address: string) {
+      reads.push(`code:${address.toLowerCase()}`);
+      return stub.code ?? "0x";
     },
   } as unknown as JsonRpcProvider;
   return { provider, reads };
@@ -217,6 +222,17 @@ describe("checkImplementation", () => {
 
     assert.equal(stats.errors, 0);
     assert.equal(stats.totalChecks, 1);
+  });
+
+  it("resolves an EIP-1167 implementation from the clone runtime", async () => {
+    const runtime = `0x363d3d373d3d3d363d73${IMPL_ADDRESS.slice(2).toLowerCase()}5af43d82803e903d91602b57fd5bf3`;
+    const { provider, reads } = stubProvider({ code: runtime });
+
+    await checkImplementation(provider, proxyEntry(IMPL_ADDRESS, "ERC1167Proxy"));
+
+    assert.equal(stats.errors, 0);
+    assert.equal(stats.totalChecks, 1);
+    assert.ok(reads.includes(`code:${PROXY_ADDRESS.toLowerCase()}`));
   });
 
   it("prints the pins-no-implementation warning even under --quiet", async () => {


### PR DESCRIPTION
State-mate currently fails implementation verification for EIP-1167 clones because they expose neither EIP-1967 storage nor implementation getters. This patch parses the canonical 45-byte clone runtime after the existing resolution steps and compares its embedded address with the configured implementation.

Tests: yarn test (189), yarn typecheck, yarn lint.

Depends on #182. Retarget this PR to main after #182 merges.