### PR TITLE
feat: add --json flag for machine-readable output

### DIFF
--- a/.claude/skills/state-mate/skill.md
+++ b/.claude/skills/state-mate/skill.md
@@ -383,6 +383,7 @@ yarn start config.yml -o l1/contractName                  # specific contract (g
 yarn start config.yml -o l1/contractName/checks/funcName  # single function
 yarn start <directory> --update-abi                       # rebuild the store: re-download all, drop unreferenced
 yarn start config.yml --quiet                             # failures and totals only (CI uses this)
+yarn start config.yml --json                              # one JSON report on stdout: verdict, counters, failed checks (docs/json-output.md)
 ```
 
 ## Best practices

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Validates EVM smart-contract state against YAML configs. Calls view functions on
 
 ## Scripts (package.json)
 
-- `yarn start <config|directory>` — run a config, or every config in a directory (add `-o …` for scope, `--update-abi` to rebuild the ABI store; `-o` is file-only).
+- `yarn start <config|directory>` — run a config, or every config in a directory (add `-o …` for scope, `--update-abi` to rebuild the ABI store, `--json` for one machine-readable report on stdout, format in `docs/json-output.md`; `-o` is file-only).
 - `yarn schemas` — regenerate JSON schemas after touching `src/typebox.ts`.
 - `yarn lint` (biome: TS/JSON lint, format and import order) / `yarn format` (prettier: YAML and Markdown only) / `yarn typecheck` (`tsc --noEmit`, since biome has no type-aware rules) — all three are CI-gated; `yarn lint:fix` and `yarn format:fix` write.
 - `yarn test` — unit tests on `node:test` (`tests/**/*.test.ts`); `yarn test:coverage` adds the coverage report. Note `tsconfig.json` excludes `tests/`, so a type error in a test only shows up when the suite runs, not under `yarn typecheck`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="docs/how-to.md">How-To Guides</a> ·
   <a href="docs/configuration.md">Configuration Reference</a> ·
   <a href="docs/cli.md">CLI Reference</a> ·
+  <a href="docs/json-output.md">JSON Output</a> ·
   <a href="docs/abi-and-proxies.md">ABI &amp; Proxies</a>
 </p>
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,13 +8,14 @@ yarn start <config-path> [options]
 
 `config-path` is one YAML file or a directory containing YAML files.
 
-| Option                        | Description                                                                        |
-| ----------------------------- | ---------------------------------------------------------------------------------- |
-| `-o, --only <check-path>`     | Run one section, contract, check type, or method. Requires a single config file    |
-| `--update-abi`                | Re-download every ABI included in the run; missing ABIs download without this flag |
-| `--skip-implementation-check` | Skip automatic implementation-address verification                                 |
-| `--allow-unverified-explorer` | Download ABIs when a fixed-chain explorer cannot confirm the configured chain ID   |
-| `-q, --quiet`                 | Print contract headers, per-contract totals, warnings, and errors                  |
+| Option                        | Description                                                                                    |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `-o, --only <check-path>`     | Run one section, contract, check type, or method. Requires a single config file                |
+| `--update-abi`                | Re-download every ABI included in the run; missing ABIs download without this flag             |
+| `--skip-implementation-check` | Skip automatic implementation-address verification                                             |
+| `--allow-unverified-explorer` | Download ABIs when a fixed-chain explorer cannot confirm the configured chain ID               |
+| `-q, --quiet`                 | Print contract headers, per-contract totals, warnings, and errors                              |
+| `-J, --json`                  | Write one JSON report to stdout instead of the log; format in [json-output.md](json-output.md) |
 
 The filter format is `section/contract/check-type/method`. Each segment after `section` is optional:
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -48,3 +48,11 @@ yarn start path/to/configs --quiet
 ```
 
 Quiet mode keeps contract headers, per-contract totals, warnings, and errors.
+
+## Read the results from a script
+
+```sh
+yarn start path/to/config.yaml --json | jq -r .status
+```
+
+`--json` replaces the log with one JSON report on stdout: the verdict, per-config counters, and every failed check with its location. Contracts whose checks all passed are not listed. The format is documented in [json-output.md](json-output.md).

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -23,7 +23,7 @@ yarn start path/to/config.yaml --only l1/vault/checks
 yarn start path/to/config.yaml --only l1/vault/checks/owner
 ```
 
-Filtering to a check type skips automatic implementation verification. A declared `proxyAdminOwner` check still runs.
+Filtering to a check type skips automatic implementation verification. A declared `proxyAdminOwner` check still runs, but does not count as a match: a filter that selects no check of its own is an error.
 
 ## Refresh stored ABIs
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -14,9 +14,10 @@ The report carries the verdict, the counters of every config, and the checks tha
 attention: failed checks with their message, and checks that could not run. A contract
 whose checks all passed is not listed.
 
-A run that aborts, on a missing config, an unset env var, or an ABI the store lacks for
-instance, still produces a report with `status: "error"`. Only an unexpected exception adds
-its stack to stderr.
+A run that aborts, on a missing config, an unset env var, an ABI the store lacks, or an
+`--only` filter that selects nothing, still produces a report with `status: "error"`. So does
+Ctrl+C: the report carries what ran before it, `error` reads `interrupted by SIGINT`, the exit
+code is 130. Only an unexpected exception adds its stack to stderr.
 
 ## Rules for parsers
 
@@ -26,6 +27,8 @@ its stack to stderr.
   checks, a directory run with 1.
 - Addresses appear as written in the config, checksummed or not. Compare them
   case-insensitively.
+- RPC URLs and explorer keys read from the environment are replaced by the variable name,
+  `$ETH_RPC_URL` for instance, wherever a message quotes them.
 - Later versions may add keys. Ignore unknown keys.
 
 ## Top level

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,0 +1,125 @@
+# JSON Output Format
+
+[Back to README](../README.md) · [CLI Reference](cli.md)
+
+`yarn start <config> --json` (or `-J`) writes one JSON object to stdout and nothing else. The
+human-readable log is not printed. The exit code is the same as without the flag.
+
+```sh
+yarn start path/to/config.yaml --json
+yarn start path/to/configs --json
+```
+
+The report carries the verdict, the counters of every config, and the checks that need
+attention: failed checks with their message, and checks that could not run. A contract
+whose checks all passed is not listed.
+
+A run that aborts, on a missing config, an unset env var, or an ABI the store lacks for
+instance, still produces a report with `status: "error"`. Only an unexpected exception adds
+its stack to stderr.
+
+## Rules for parsers
+
+- Keys whose value would be empty are omitted: a clean config has no `contracts`, a completed
+  run has no `error`. `summary` and `configs` are present in every report.
+- Read `status` before the exit code. A single-config run exits with the number of failed
+  checks, a directory run with 1.
+- Addresses appear as written in the config, checksummed or not. Compare them
+  case-insensitively.
+- Later versions may add keys. Ignore unknown keys.
+
+## Top level
+
+| Key                | Type                              | Meaning                                                                                                                     |
+| ------------------ | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `status`           | `"passed"`, `"failed"`, `"error"` | `passed`: every check agreed with the chain. `failed`: at least one check did not. `error`: the run aborted before the end. |
+| `exit_code`        | int                               | Process exit code, the same as without `--json`.                                                                            |
+| `duration_seconds` | float                             | Wall time of the run.                                                                                                       |
+| `filter`           | string                            | The `--only` argument, when one was given.                                                                                  |
+| `error`            | string                            | Present when the run aborted: the message the log would have printed.                                                       |
+| `summary`          | object                            | Counters over every config, described below.                                                                                |
+| `configs`          | array                             | One entry per config file, in run order, described below.                                                                   |
+
+### `summary`
+
+```json
+"summary": { "configs": 2, "checks": 310, "errors": 1, "skipped": 12, "warnings": 1 }
+```
+
+`checks` counts checks that reached a verdict, `errors` those whose verdict was a mismatch.
+`skipped` counts checks that did not run: methods the config pins to `null`, and scans the
+chain offers no log source for. `warnings` counts the `warnings` entries below.
+
+## `configs[]`
+
+| Key                           | Present when                          | Meaning                                                                     |
+| ----------------------------- | ------------------------------------- | --------------------------------------------------------------------------- |
+| `config`                      | always                                | Path of the config file, as resolved from the command line.                 |
+| `status`                      | always                                | `passed`, `failed`, or `error` when the run aborted inside this config.     |
+| `checks`, `errors`, `skipped` | always                                | The counters of this config; see `summary`.                                 |
+| `error`                       | `status` is `error`                   | The abort message. The contracts checked before the abort are still listed. |
+| `warnings`                    | a warning fell outside every contract | Same shape as a contract's `warnings`.                                      |
+| `contracts`                   | a contract has something to report    | One entry per contract with a failure or a warning, in config order.        |
+
+## `contracts[]`
+
+| Key        | Present when          | Meaning                                                                                |
+| ---------- | --------------------- | -------------------------------------------------------------------------------------- |
+| `path`     | always                | `<section>/<alias>`, the same path `--only` accepts.                                   |
+| `name`     | always                | `name:` from the config.                                                               |
+| `address`  | always                | `address:` from the config.                                                            |
+| `failures` | a check failed        | `{ type, check, message }` per failed check.                                           |
+| `warnings` | a check could not run | `{ check, message }` per check, for example an ACL scan on a chain with no log source. |
+
+`type` names the check type: `checks`, `storage`, `proxyChecks`, `implementationChecks`,
+`ozAcl`, `ozNonEnumerableAcl`, `aragonAcl`, or one of the automatic checks `implementation`,
+`proxyAdmin`, `proxyAdminOwner`. `check` is the method with its arguments, the storage slot,
+or the role and holder, as the log would print it. `message` is the log's failure text with
+the colours stripped; on a value mismatch it quotes both the expected and the actual value.
+
+## Example
+
+```json
+{
+  "status": "failed",
+  "exit_code": 1,
+  "duration_seconds": 2.4,
+  "summary": { "configs": 1, "checks": 8, "errors": 1, "skipped": 1, "warnings": 0 },
+  "configs": [
+    {
+      "config": "configs/example/mainnet/strategy.yaml",
+      "status": "failed",
+      "checks": 8,
+      "errors": 1,
+      "skipped": 1,
+      "contracts": [
+        {
+          "path": "l1/callForwarder",
+          "name": "CallForwarder",
+          "address": "0x7305bB45aF91893B7BCaF0Ad8Eae37cb16820Bb8",
+          "failures": [
+            {
+              "check": "owner",
+              "message": "Expected \"0x000000000000000000000000000000000000dEaD\" to equal actual \"0x0000000000000000000000000000000000000000\"",
+              "type": "checks"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+`jq` examples:
+
+```sh
+# Overall verdict
+yarn start cfg.yaml --json | jq -r .status
+
+# Every failed check with its location
+yarn start cfg.yaml --json | jq '.configs[].contracts[]? | select(.failures) | {path, failures}'
+
+# Configs that did not pass, in a directory run
+yarn start configs/ --json | jq '.configs[] | select(.status != "passed") | {config, status, errors}'
+```

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -27,8 +27,9 @@ code is 130. Only an unexpected exception adds its stack to stderr.
   checks, a directory run with 1.
 - Addresses appear as written in the config, checksummed or not. Compare them
   case-insensitively.
-- RPC URLs and explorer keys read from the environment are replaced by the variable name,
-  `$ETH_RPC_URL` for instance, wherever a message quotes them.
+- RPC URLs and explorer keys are replaced wherever a message quotes them: a value read from
+  the environment by the variable name, `$ETH_RPC_URL` for instance, a URL written in the
+  config by `<rpcUrl>`.
 - Later versions may add keys. Ignore unknown keys.
 
 ## Top level

--- a/src/acl/log-source.ts
+++ b/src/acl/log-source.ts
@@ -1,6 +1,7 @@
 import type { JsonRpcProvider } from "ethers";
 
 import { printError } from "../common";
+import { registerSecret } from "../context";
 import { httpGetAsync, isTransientExplorerHttpError } from "../explorer";
 import { log } from "../logger";
 import { parseRoleLog, type RawLog, ROLE_GRANTED_TOPIC, type RoleEvent } from "./fold";
@@ -135,6 +136,7 @@ async function explorerGet(url: string): Promise<ExplorerLogsResponse> {
 function explorerUrl(source: LogSource, chainId: string, query: string): string {
   if (source.kind === "blockscout") return `https://${source.hostname}/api?${query}`;
   const key = process.env.ETHERSCAN_TOKEN;
+  if (key) registerSecret(key, "$ETHERSCAN_TOKEN");
   return `https://api.etherscan.io/v2/api?chainid=${chainId}&${query}${key ? `&apikey=${key}` : ""}`;
 }
 

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -1,8 +1,8 @@
-import { program } from "commander";
+import { CommanderError, program } from "commander";
 
-import { EntryField } from "./common";
-import type { CheckOnly } from "./context";
-import { logErrorAndExit } from "./logger";
+import { EntryField, printError } from "./common";
+import { type CheckOnly, context } from "./context";
+import { FatalError, logErrorAndExit } from "./logger";
 
 type CheckOnlyOptionType = null | CheckOnly;
 
@@ -18,10 +18,34 @@ export function parseCommandLineArguments() {
     .option("--skip-implementation-check", "do not verify implementation addresses against the chain")
     .option("--allow-unverified-explorer", "download ABIs even when the explorer does not confirm the config's chainId")
     .option("-q, --quiet", "print only contract headers, per-contract totals and errors")
-    .parse();
+    .option("-J, --json", "one JSON report on stdout: verdict, counters, failed checks; see docs/json-output.md");
+
+  // A usage error under --json must reach the caller as a report, so commander may neither
+  // print nor exit on its own; the flag is read off argv because parsing is what failed
+  let usageError = "";
+  program.exitOverride().configureOutput({
+    writeErr: (text) => {
+      usageError += text;
+    },
+  });
+  try {
+    program.parse();
+  } catch (error) {
+    if (error instanceof CommanderError && error.exitCode === 0) process.exit(0);
+    if (process.argv.includes("--json") || process.argv.includes("-J")) {
+      context.json = true;
+      throw new FatalError(usageError.trim() || printError(error));
+    }
+    process.stderr.write(usageError);
+    process.exit(error instanceof CommanderError ? error.exitCode : 1);
+  }
 
   const configPath = program.args[0];
   const options = program.opts();
+  // Set before the -o validation below, so that a malformed filter is reported the way the caller
+  // asked, and under the filter they gave
+  context.json = Boolean(options.json);
+  context.checkOnlyCmdArg = options.only;
   let checkOnly: CheckOnlyOptionType = null;
   if (options.only) {
     const checksPath = String(options.only).split("/");
@@ -46,5 +70,6 @@ export function parseCommandLineArguments() {
     skipImplementationCheck: Boolean(options.skipImplementationCheck),
     allowUnverifiedExplorer: Boolean(options.allowUnverifiedExplorer),
     quiet: Boolean(options.quiet),
+    json: Boolean(options.json),
   };
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,6 +28,7 @@ export function printError(error: unknown): string {
 
 export function readUrlOrFromEnvironment(urlOrEnvironmentVariableName: string) {
   if (isUrl(urlOrEnvironmentVariableName)) {
+    registerSecret(urlOrEnvironmentVariableName, "<rpcUrl>");
     return urlOrEnvironmentVariableName;
   }
   const valueFromEnvironment = process.env[urlOrEnvironmentVariableName];

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 
+import { registerSecret } from "./context";
 import { logErrorAndExit } from "./logger";
 import type { Abi, AbiArgumentsLength, ChainId } from "./types";
 
@@ -38,6 +39,7 @@ export function readUrlOrFromEnvironment(urlOrEnvironmentVariableName: string) {
       `Env var ${chalk.yellow(urlOrEnvironmentVariableName)} is not a valid RPC url: ${chalk.yellow(valueFromEnvironment)}`,
     );
   }
+  registerSecret(valueFromEnvironment, `$${urlOrEnvironmentVariableName}`);
   return valueFromEnvironment;
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -34,12 +34,12 @@ export function readUrlOrFromEnvironment(urlOrEnvironmentVariableName: string) {
   if (!valueFromEnvironment) {
     logErrorAndExit(`Env var ${chalk.yellow(urlOrEnvironmentVariableName)} is not set`);
   }
+  registerSecret(valueFromEnvironment, `$${urlOrEnvironmentVariableName}`);
   if (!isUrl(valueFromEnvironment)) {
     logErrorAndExit(
       `Env var ${chalk.yellow(urlOrEnvironmentVariableName)} is not a valid RPC url: ${chalk.yellow(valueFromEnvironment)}`,
     );
   }
-  registerSecret(valueFromEnvironment, `$${urlOrEnvironmentVariableName}`);
   return valueFromEnvironment;
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -26,6 +26,8 @@ export const context = {
   skipImplementationCheck: false,
   allowUnverifiedExplorer: false,
   quiet: false,
+  // --json: one report on stdout instead of the log; see docs/json-output.md
+  json: false,
 };
 
 export const stats = {

--- a/src/context.ts
+++ b/src/context.ts
@@ -30,6 +30,20 @@ export const context = {
   json: false,
 };
 
+// Values read from the environment that no report may echo back: RPC URLs carry keys, and
+// ethers quotes the request URL in its error text. Value → the placeholder that replaces it
+const secrets = new Map<string, string>();
+
+export function registerSecret(value: string, placeholder: string): void {
+  if (value) secrets.set(value, placeholder);
+}
+
+export function redactSecrets(text: string): string {
+  let redacted = text;
+  for (const [value, placeholder] of secrets) redacted = redacted.split(value).join(placeholder);
+  return redacted;
+}
+
 export const stats = {
   totalChecks: 0,
   // Methods the config left as null: counted apart from totalChecks, which must mean "verified"

--- a/src/context.ts
+++ b/src/context.ts
@@ -48,6 +48,9 @@ export const stats = {
   totalChecks: 0,
   // Methods the config left as null: counted apart from totalChecks, which must mean "verified"
   skipped: 0,
+  // Checks and skips the -o filter selected; automatic checks do not count towards a filter
+  // that names a checks type, so that one cannot pass for a method that matched nothing
+  selected: 0,
   errors: 0,
   errorDetails: [] as ErrorDetail[],
 };
@@ -56,6 +59,7 @@ export const stats = {
 export function resetStats(): void {
   stats.totalChecks = 0;
   stats.skipped = 0;
+  stats.selected = 0;
   stats.errors = 0;
   stats.errorDetails.length = 0;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import * as readline from "node:readline";
 import chalk from "chalk";
 
 import { context } from "./context";
+import { recordWarning } from "./report";
 
 export const SUCCESS_MARK = chalk.green("✔");
 export const FAILURE_MARK = chalk.red("✘");
@@ -30,12 +31,13 @@ export class LogCommand {
   }
 
   private initialPrint(): void {
-    if (context.quiet) return;
+    if (context.quiet || context.json) return;
     const prefix = getItemPrefix();
     process.stdout.write(`${prefix}  ${this.description}: ...`);
   }
 
   public printResult(statusSymbol: string, result: string): void {
+    if (context.json) return;
     const prefix = getItemPrefix();
     if (!context.quiet) {
       readline.cursorTo(process.stdout, 0);
@@ -55,6 +57,7 @@ export class LogCommand {
 
   public warning(result: string): void {
     // A warning is a check that did not happen; --quiet must not hide that from CI logs
+    recordWarning(this.description, result);
     this.printResult(WARNING_MARK, result);
   }
 }
@@ -76,7 +79,7 @@ export function logSubHeader(path: string, isLast: boolean = false) {
 }
 
 export function logMethodSkipped(methodName: string) {
-  if (context.quiet) return;
+  if (context.quiet || context.json) return;
   const prefix = getItemPrefix();
   log(`${prefix}${WARNING_MARK} .${methodName}: ${chalk.yellow("skipped")}`);
 }
@@ -89,15 +92,21 @@ export function logFinalStatus(message: string, isSuccess: boolean, isLast: bool
 }
 
 export function log(argument: unknown) {
+  if (context.json) return;
   console.log(argument);
 }
 
 export function logError(argument: unknown) {
+  if (context.json) return;
   const prefix = getItemPrefix();
   console.error(`${prefix}ERROR: ${String(argument)}`);
 }
 
+/** A run-ending error under --json: the entrypoint turns it into the report instead of exiting here. */
+export class FatalError extends Error {}
+
 export function logErrorAndExit(argument: unknown): never {
+  if (context.json) throw new FatalError(String(argument));
   logError(argument);
   console.trace();
   process.exit(1);

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,0 +1,142 @@
+import { stripVTControlCharacters } from "node:util";
+
+import { context, stats } from "./context";
+
+// The --json report: the verdict, the counters and nothing that passed. Collected on every
+// run and written only when the flag asks for it, so the validators never branch on the mode.
+
+type Status = "error" | "failed" | "passed";
+
+interface Failure {
+  check: string;
+  message: string;
+  type: string;
+}
+
+interface Warning {
+  check: string;
+  message: string;
+}
+
+interface ContractReport {
+  address: string;
+  failures?: Failure[];
+  name: string;
+  path: string;
+  warnings?: Warning[];
+}
+
+interface ConfigReport {
+  checks: number;
+  config: string;
+  contracts?: ContractReport[];
+  error?: string;
+  errors: number;
+  skipped: number;
+  status: Status;
+  warnings?: Warning[];
+}
+
+export interface Report {
+  configs: ConfigReport[];
+  duration_seconds: number;
+  error?: string;
+  exit_code: number;
+  filter?: string;
+  status: Status;
+  summary: { checks: number; configs: number; errors: number; skipped: number; warnings: number };
+}
+
+const startedAt = Date.now();
+let configs: ConfigReport[] = [];
+let config: ConfigReport | undefined;
+let contract: ContractReport | undefined;
+// Failures are read back from stats.errorDetails, which every error path already feeds
+let failuresBefore = 0;
+
+const plain = (text: string) => stripVTControlCharacters(text);
+
+export function resetReport(): void {
+  configs = [];
+  config = undefined;
+  contract = undefined;
+}
+
+export function beginConfig(configPath: string): void {
+  config = { config: configPath, status: "passed", checks: 0, errors: 0, skipped: 0 };
+  configs.push(config);
+}
+
+export function endConfig(): void {
+  if (!config) return;
+  config.checks = stats.totalChecks;
+  config.errors = stats.errors;
+  config.skipped = stats.skipped;
+  config.status = stats.errors ? "failed" : "passed";
+  config = undefined;
+}
+
+export function beginContract(path: string, name: string, address: string): void {
+  contract = { path, name, address };
+  failuresBefore = stats.errorDetails.length;
+}
+
+/** A contract enters the report only with something to say: a failed check or a check that did not run. */
+export function endContract(): void {
+  if (!contract) return;
+  const failures = stats.errorDetails
+    .slice(failuresBefore)
+    .map(({ checksType, method, message }) => ({ check: method, message: plain(message), type: checksType }));
+  if (failures.length > 0) contract.failures = failures;
+  if (config && (contract.failures || contract.warnings)) {
+    config.contracts ??= [];
+    config.contracts.push(contract);
+  }
+  contract = undefined;
+}
+
+export function recordWarning(check: string, message: string): void {
+  const target = contract ?? config;
+  if (!target) return;
+  target.warnings ??= [];
+  target.warnings.push({ check: plain(check), message: plain(message) });
+}
+
+export function buildReport(exitCode: number, error?: string): Report {
+  // A run that aborted leaves its config, and maybe a contract, open; what they reached is still worth reading
+  if (config && error) {
+    endContract();
+    endConfig();
+    const aborted = configs.at(-1)!;
+    aborted.status = "error";
+    aborted.error = plain(error);
+  }
+  const summary = { configs: configs.length, checks: 0, errors: 0, skipped: 0, warnings: 0 };
+  for (const entry of configs) {
+    summary.checks += entry.checks;
+    summary.errors += entry.errors;
+    summary.skipped += entry.skipped;
+    summary.warnings += entry.warnings?.length ?? 0;
+    for (const item of entry.contracts ?? []) summary.warnings += item.warnings?.length ?? 0;
+  }
+  const status: Status = error ? "error" : summary.errors ? "failed" : "passed";
+  return {
+    status,
+    exit_code: exitCode,
+    duration_seconds: Math.round((Date.now() - startedAt) / 100) / 10,
+    filter: context.checkOnlyCmdArg,
+    error: error === undefined ? undefined : plain(error),
+    summary,
+    configs,
+  };
+}
+
+/**
+ * Sets the exit code instead of exiting: a pipe takes a large report in several writes, and
+ * process.exit would cut it after the first one.
+ */
+export function emitReport(exitCode: number, error?: string): void {
+  if (!context.json) return;
+  process.stdout.write(`${JSON.stringify(buildReport(exitCode, error), null, 2)}\n`);
+  process.exitCode = exitCode;
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,6 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
 
-import { context, stats } from "./context";
+import { context, redactSecrets, stats } from "./context";
 
 // The --json report: the verdict, the counters and nothing that passed. Collected on every
 // run and written only when the flag asks for it, so the validators never branch on the mode.
@@ -54,12 +54,15 @@ let contract: ContractReport | undefined;
 // Failures are read back from stats.errorDetails, which every error path already feeds
 let failuresBefore = 0;
 
-const plain = (text: string) => stripVTControlCharacters(text);
+let emitted = false;
+
+const plain = (text: string) => redactSecrets(stripVTControlCharacters(text));
 
 export function resetReport(): void {
   configs = [];
   config = undefined;
   contract = undefined;
+  emitted = false;
 }
 
 export function beginConfig(configPath: string): void {
@@ -132,11 +135,13 @@ export function buildReport(exitCode: number, error?: string): Report {
 }
 
 /**
- * Sets the exit code instead of exiting: a pipe takes a large report in several writes, and
- * process.exit would cut it after the first one.
+ * Writes the report once. Sets the exit code instead of exiting: a pipe takes a large report in
+ * several writes, and process.exit would cut it after the first one; a caller that must exit
+ * on the spot does so from onFlushed.
  */
-export function emitReport(exitCode: number, error?: string): void {
-  if (!context.json) return;
-  process.stdout.write(`${JSON.stringify(buildReport(exitCode, error), null, 2)}\n`);
+export function emitReport(exitCode: number, error?: string, onFlushed?: () => void): void {
+  if (!context.json || emitted) return;
+  emitted = true;
+  process.stdout.write(`${JSON.stringify(buildReport(exitCode, error), null, 2)}\n`, onFlushed);
   process.exitCode = exitCode;
 }

--- a/src/section-validators/base.ts
+++ b/src/section-validators/base.ts
@@ -167,12 +167,20 @@ export abstract class SectionValidatorBase {
       incErrors(errorMessage);
       return;
     }
+    let actual: unknown;
     try {
-      const actual: unknown = await contractFunction.staticCall(...(args || ""));
+      actual = await contractFunction.staticCall(...(args || ""));
+    } catch (error) {
+      const errorMessage = `REVERTED with: ${printError(error)}`;
+      logHandle.failure(errorMessage);
+      incErrors(errorMessage);
+      return;
+    }
+    try {
       _assertEqual(actual, expected);
       logHandle.success(_stringify(actual));
     } catch (error) {
-      const errorMessage = `REVERTED with: ${printError(error)}`;
+      const errorMessage = printError(error);
       logHandle.failure(errorMessage);
       incErrors(errorMessage);
     }

--- a/src/section-validators/base.ts
+++ b/src/section-validators/base.ts
@@ -63,11 +63,21 @@ export function incErrors(errorMessage?: string): void {
 export function incChecks(): void {
   stats.totalChecks += 1;
   contractChecks += 1;
+  countSelected();
 }
 
 export function incSkipped(): void {
   stats.skipped += 1;
   contractSkipped += 1;
+  countSelected();
+}
+
+// The checks that run without being declared under a checks type
+const AUTOMATIC_CHECKS = new Set(["implementation", "proxyAdmin", "proxyAdminOwner"]);
+
+function countSelected(): void {
+  if (context.checkOnly?.checksType && AUTOMATIC_CHECKS.has(currentErrorContext.checksType ?? "")) return;
+  stats.selected += 1;
 }
 
 export enum CheckLevel {

--- a/src/section-validators/contract.ts
+++ b/src/section-validators/contract.ts
@@ -3,6 +3,7 @@ import type { JsonRpcProvider } from "ethers";
 
 import { EntryField } from "src/common";
 import { logFinalStatus, logHeader1, logHeader2 } from "src/logger";
+import { beginContract, endContract } from "src/report";
 import type { ContractEntry } from "src/typebox";
 import type { ChainId } from "src/types";
 import { AragonAclSectionValidator } from "./aragon-acl";
@@ -85,6 +86,7 @@ export class ContractSectionValidator {
     resetContractCounters();
 
     logHeader1(`Contract: ${sectionTitle}/${contractAlias} (${contractEntry.name}, ${contractEntry.address})`);
+    beginContract(`${sectionTitle}/${contractAlias}`, contractEntry.name, contractEntry.address);
 
     // Set base error context for this contract
     setErrorContext({
@@ -139,6 +141,7 @@ export class ContractSectionValidator {
 
     // Show contract status (not last, global status follows)
     const { checks, errors, skipped } = getContractStats();
+    endContract();
     const skippedNote = skipped ? `, ${chalk.yellow(`${skipped} skipped`)}` : "";
     const statusMessage = errors
       ? `${checks} checks, ${chalk.red(`${errors} ${errors === 1 ? "error" : "errors"}`)}${skippedNote}`

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -20,7 +20,7 @@ import {
 } from "./abi-provider";
 import { parseCommandLineArguments } from "./cli-parser";
 import { normalizeChainId, printError, readUrlOrFromEnvironment } from "./common";
-import { context, resetStats, stats } from "./context";
+import { context, registerSecret, resetStats, stats } from "./context";
 import {
   assertProviderChain,
   createProvider,
@@ -135,6 +135,12 @@ async function doChecks(jsonDocument: EntireDocument) {
   for (const [sectionTitle, section] of Object.entries(jsonDocument)) {
     if (isTypeOfTB(section, NetworkSectionTB)) await checkNetworkSection(sectionTitle, section);
   }
+  // A filter that selects nothing verified nothing, and "passed" would say otherwise
+  if (context.checkOnly && stats.totalChecks + stats.skipped === 0) {
+    logErrorAndExit(
+      `${chalk.yellow(`-o "${context.checkOnlyCmdArg}"`)} matched nothing in ${chalk.magenta(context.configPath)}`,
+    );
+  }
   // Show final summary (outside the tree)
   log(""); // Separator line
   const statusMark = stats.errors ? FAILURE_MARK : SUCCESS_MARK;
@@ -212,6 +218,7 @@ async function iterateLoadedContracts(
         continue;
       }
       const explorerKey = explorerTokenEnv ? process.env[explorerTokenEnv] : "";
+      if (explorerKey) registerSecret(explorerKey, `$${explorerTokenEnv}`);
 
       if (!explorerTokenEnv && explorerNeedsApiKey(explorerHostname)) {
         log(
@@ -304,6 +311,10 @@ export function collectYamlConfigs(directory: string): string[] {
 
 async function main() {
   Object.assign(context, parseCommandLineArguments());
+  if (context.json) {
+    // Ctrl+C must still leave one parseable report, carrying whatever ran before it
+    process.once("SIGINT", () => emitReport(130, "interrupted by SIGINT", () => process.exit(130)));
+  }
 
   if (!fs.existsSync(context.configPath)) {
     logErrorAndExit(`No such file or directory: ${chalk.magenta(context.configPath)}`);

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -28,7 +28,17 @@ import {
   loadContractInfo,
   verifyChainIdWithExplorer,
 } from "./explorer";
-import { FAILURE_MARK, log, logError, logErrorAndExit, logHeader1, SUCCESS_MARK, WARNING_MARK } from "./logger";
+import {
+  FAILURE_MARK,
+  FatalError,
+  log,
+  logError,
+  logErrorAndExit,
+  logHeader1,
+  SUCCESS_MARK,
+  WARNING_MARK,
+} from "./logger";
+import { beginConfig, emitReport, endConfig } from "./report";
 import { ContractSectionValidator } from "./section-validators/contract";
 import {
   type EntireDocument,
@@ -313,7 +323,9 @@ async function main() {
       resetAbiCache();
       resetStats();
       logHeader1(configPath);
+      beginConfig(configPath);
       await runConfig();
+      endConfig();
       if (stats.errors) failed.push(`${configPath} (${stats.errors} errors)`);
     }
     pruneAbiStores();
@@ -322,16 +334,29 @@ async function main() {
       logError(
         `${FAILURE_MARK} ${chalk.bold(`${failed.length}/${configs.length} configs failed:`)}\n${failed.join("\n")}`,
       );
-      process.exit(1);
+      exit(1);
+      return;
     }
     log(`${SUCCESS_MARK} ${chalk.bold(`All ${configs.length} configs passed`)}`);
+    exit(0);
     return;
   }
 
   // No prune here: a single-file run has walked only its own addresses, and sweeping the shared
   // store now would drop the sibling configs' ABIs
+  beginConfig(context.configPath);
   await runConfig();
-  if (stats.errors) process.exit(stats.errors);
+  endConfig();
+  exit(stats.errors);
+}
+
+// Under --json the report owns the exit code; the log mode keeps exiting on the spot
+function exit(code: number): void {
+  if (context.json) {
+    emitReport(code);
+  } else if (code) {
+    process.exit(code);
+  }
 }
 
 async function runConfig() {
@@ -346,7 +371,13 @@ async function runConfig() {
 // Do not run when imported (e.g. by unit tests) — only as the CLI entrypoint
 if (require.main === module) {
   main().catch((error) => {
-    logError(error);
+    if (context.json) {
+      emitReport(1, printError(error));
+      // A FatalError is fully told by the report; anything else is a bug worth its stack
+      if (!(error instanceof FatalError)) console.error(error);
+    } else {
+      logError(error);
+    }
     process.exitCode = 1;
   });
 }

--- a/src/state-mate.ts
+++ b/src/state-mate.ts
@@ -136,7 +136,7 @@ async function doChecks(jsonDocument: EntireDocument) {
     if (isTypeOfTB(section, NetworkSectionTB)) await checkNetworkSection(sectionTitle, section);
   }
   // A filter that selects nothing verified nothing, and "passed" would say otherwise
-  if (context.checkOnly && stats.totalChecks + stats.skipped === 0) {
+  if (context.checkOnly && stats.selected === 0) {
     logErrorAndExit(
       `${chalk.yellow(`-o "${context.checkOnlyCmdArg}"`)} matched nothing in ${chalk.magenta(context.configPath)}`,
     );

--- a/tests/check-counting.test.ts
+++ b/tests/check-counting.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 
 import type { Contract, JsonRpcProvider } from "ethers";
 
 import { EntryField } from "../src/common";
-import { resetStats, stats } from "../src/context";
-import { resetContractCounters } from "../src/section-validators/base";
+import { context, resetStats, stats } from "../src/context";
+import { resetContractCounters, setErrorContext } from "../src/section-validators/base";
 import { ChecksSectionValidator } from "../src/section-validators/checks";
 import type { StaticCallCheck } from "../src/typebox";
 
@@ -45,5 +45,34 @@ describe("check accounting", () => {
       { checks: stats.totalChecks, skipped: stats.skipped, errors: stats.errors },
       { checks: 1, skipped: 2, errors: 0 },
     );
+  });
+});
+
+describe("filter selection accounting", () => {
+  const validator = new ExposedChecks({} as JsonRpcProvider, 1, EntryField.checks);
+
+  beforeEach(() => {
+    resetStats();
+    resetContractCounters();
+    context.checkOnly = { section: "l1", contract: "vault", checksType: "checks", method: "ownre" };
+  });
+
+  afterEach(() => {
+    context.checkOnly = null;
+  });
+
+  it("does not let an automatic check stand in for a method the filter named", async () => {
+    setErrorContext({ checksType: "proxyAdmin" });
+    await validator.run("proxyAdmin", { mustRevert: true } as unknown as StaticCallCheck);
+
+    assert.deepEqual({ checks: stats.totalChecks, selected: stats.selected }, { checks: 1, selected: 0 });
+  });
+
+  it("counts a check under the named checks type as selected, skipped ones included", async () => {
+    setErrorContext({ checksType: "checks" });
+    await validator.run("owner", { mustRevert: true } as unknown as StaticCallCheck);
+    await validator.run("nonce", { result: null } as unknown as StaticCallCheck);
+
+    assert.equal(stats.selected, 2);
   });
 });

--- a/tests/json-report.test.ts
+++ b/tests/json-report.test.ts
@@ -1,13 +1,23 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import chalk from "chalk";
 
-import { context, resetStats, stats } from "../src/context";
+import { context, registerSecret, resetStats, stats } from "../src/context";
 import { FatalError, LogCommand, logErrorAndExit } from "../src/logger";
-import { beginConfig, beginContract, buildReport, endConfig, endContract, resetReport } from "../src/report";
+import {
+  beginConfig,
+  beginContract,
+  buildReport,
+  emitReport,
+  endConfig,
+  endContract,
+  resetReport,
+} from "../src/report";
 import { incChecks, incErrors, resetContractCounters, setErrorContext } from "../src/section-validators/base";
 
 const ADDRESS = "0x7305bB45aF91893B7BCaF0Ad8Eae37cb16820Bb8";
@@ -110,6 +120,42 @@ describe("--json report", () => {
     ]);
   });
 
+  it("replaces an RPC URL read from the environment wherever an error quotes it", () => {
+    registerSecret("https://rpc.example/v1/KEY123", "$ETH_RPC_URL");
+    beginConfig("cfg.yaml");
+    beginContract("l1/vault", "Vault", ADDRESS);
+    setErrorContext({ checksType: "checks", method: "owner" });
+    incErrors(`server response 403 (info={ "requestUrl": "https://rpc.example/v1/KEY123" })`);
+
+    const report = rendered(1, "https://rpc.example/v1/KEY123 answered 403");
+    assert.equal(report.error, "$ETH_RPC_URL answered 403");
+    assert.equal(
+      report.configs[0].contracts[0].failures[0].message,
+      `server response 403 (info={ "requestUrl": "$ETH_RPC_URL" })`,
+    );
+  });
+
+  it("writes the report once, however many times the run tries to finish", () => {
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    const originalExitCode = process.exitCode;
+    process.stdout.write = ((chunk: string, callback?: () => void) => {
+      writes.push(String(chunk));
+      callback?.();
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      emitReport(130, "interrupted by SIGINT");
+      emitReport(0);
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = originalExitCode;
+    }
+
+    assert.equal(writes.length, 1);
+    assert.equal(JSON.parse(writes[0]).error, "interrupted by SIGINT");
+  });
+
   it("turns a run-ending error into an exception instead of exiting the process", () => {
     assert.throws(() => logErrorAndExit("boom"), FatalError);
   });
@@ -138,6 +184,24 @@ describe("--json report", () => {
     assert.equal(JSON.parse(run.stdout).status, "error");
     assert.match(JSON.parse(run.stdout).error, /checkOnly/);
     assert.equal(JSON.parse(run.stdout).filter, "a/b/c/d/e");
+  });
+
+  it("rejects a filter that selects nothing instead of passing an empty run", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "state-mate-json-"));
+    const config = path.join(directory, "cfg.yaml");
+    fs.writeFileSync(config, "deployed:\n  l1: []\nl1:\n  rpcUrl: ETH_RPC_URL\n  chainId: 1\n  contracts: {}\n");
+    try {
+      const run = runCli(config, "--json", "-o", "l2");
+
+      assert.equal(run.status, 1);
+      assert.equal(run.stderr, "");
+      const report = JSON.parse(run.stdout);
+      assert.equal(report.status, "error");
+      assert.match(report.error, /matched nothing/);
+      assert.equal(report.summary.checks, 0);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("writes nothing but the report to stdout when the run aborts before any config", () => {

--- a/tests/json-report.test.ts
+++ b/tests/json-report.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import chalk from "chalk";
+
+import { context, resetStats, stats } from "../src/context";
+import { FatalError, LogCommand, logErrorAndExit } from "../src/logger";
+import { beginConfig, beginContract, buildReport, endConfig, endContract, resetReport } from "../src/report";
+import { incChecks, incErrors, resetContractCounters, setErrorContext } from "../src/section-validators/base";
+
+const ADDRESS = "0x7305bB45aF91893B7BCaF0Ad8Eae37cb16820Bb8";
+
+// What a consumer parses: undefined keys are gone once the report is serialized
+const rendered = (exitCode: number, error?: string) => JSON.parse(JSON.stringify(buildReport(exitCode, error)));
+
+describe("--json report", () => {
+  beforeEach(() => {
+    resetStats();
+    resetContractCounters();
+    resetReport();
+    context.json = true;
+  });
+
+  afterEach(() => {
+    context.json = false;
+  });
+
+  it("reduces a clean run to the verdict and the counters, listing no contract", () => {
+    beginConfig("cfg.yaml");
+    beginContract("l1/vault", "Vault", ADDRESS);
+    incChecks();
+    incChecks();
+    endContract();
+    endConfig();
+
+    const report = rendered(0);
+    assert.equal(report.status, "passed");
+    assert.deepEqual(report.summary, { configs: 1, checks: 2, errors: 0, skipped: 0, warnings: 0 });
+    assert.deepEqual(report.configs, [{ config: "cfg.yaml", status: "passed", checks: 2, errors: 0, skipped: 0 }]);
+    assert.equal("filter" in report, false);
+    assert.equal("error" in report, false);
+  });
+
+  it("lists a failed check under its contract with the section type and a colour-free message", () => {
+    beginConfig("cfg.yaml");
+    beginContract("l1/ok", "Ok", ADDRESS);
+    incChecks();
+    endContract();
+    beginContract("l1/vault", "Vault", ADDRESS);
+    incChecks();
+    setErrorContext({ checksType: "checks", method: "owner" });
+    incErrors(`Expected ${chalk.yellow("0x1")} to equal actual ${chalk.red("0x2")}`);
+    endContract();
+    endConfig();
+
+    const report = rendered(1);
+    assert.equal(report.status, "failed");
+    assert.equal(report.configs[0].status, "failed");
+    assert.deepEqual(report.configs[0].contracts, [
+      {
+        path: "l1/vault",
+        name: "Vault",
+        address: ADDRESS,
+        failures: [{ check: "owner", message: "Expected 0x1 to equal actual 0x2", type: "checks" }],
+      },
+    ]);
+  });
+
+  it("keeps a check that could not run visible as a warning on its contract", () => {
+    beginConfig("cfg.yaml");
+    beginContract("l1/vault", "Vault", ADDRESS);
+    new LogCommand("exhaustive ACL scan").warning("no log source is known for chainId 7");
+    endContract();
+    endConfig();
+
+    const report = rendered(0);
+    assert.equal(report.status, "passed");
+    assert.equal(report.summary.warnings, 1);
+    assert.deepEqual(report.configs[0].contracts[0].warnings, [
+      { check: "exhaustive ACL scan", message: "no log source is known for chainId 7" },
+    ]);
+  });
+
+  it("marks the config an aborted run left open as error and carries the message to the top", () => {
+    beginConfig("cfg.yaml");
+    beginContract("l1/vault", "Vault", ADDRESS);
+    stats.totalChecks = 4;
+
+    const report = rendered(1, `Env var ${chalk.yellow("ETH_RPC_URL")} is not set`);
+    assert.equal(report.status, "error");
+    assert.equal(report.exit_code, 1);
+    assert.equal(report.error, "Env var ETH_RPC_URL is not set");
+    assert.equal(report.configs[0].status, "error");
+    assert.equal(report.configs[0].error, "Env var ETH_RPC_URL is not set");
+    assert.equal(report.configs[0].checks, 4);
+  });
+
+  it("keeps the failures of the contract an abort interrupted", () => {
+    beginConfig("cfg.yaml");
+    beginContract("l1/vault", "Vault", ADDRESS);
+    setErrorContext({ checksType: "implementation", method: "implementation" });
+    incErrors("delegates to 0x1, while the config expects 0x2");
+
+    const report = rendered(1, "No consolidated ABI file found");
+    assert.equal(report.configs[0].status, "error");
+    assert.deepEqual(report.configs[0].contracts[0].failures, [
+      { check: "implementation", message: "delegates to 0x1, while the config expects 0x2", type: "implementation" },
+    ]);
+  });
+
+  it("turns a run-ending error into an exception instead of exiting the process", () => {
+    assert.throws(() => logErrorAndExit("boom"), FatalError);
+  });
+
+  const runCli = (...args: string[]) =>
+    spawnSync(
+      process.execPath,
+      ["--require", "ts-node/register", "--require", "tsconfig-paths/register", "src/state-mate.ts", ...args],
+      { cwd: path.resolve(__dirname, ".."), encoding: "utf8" },
+    );
+
+  it("reports a usage error commander rejects, such as a missing config path", () => {
+    const run = runCli("--json");
+
+    assert.equal(run.status, 1);
+    assert.equal(run.stderr, "");
+    assert.equal(JSON.parse(run.stdout).status, "error");
+    assert.match(JSON.parse(run.stdout).error, /config-path/);
+  });
+
+  it("reports a malformed --only filter instead of exiting with a stack trace", () => {
+    const run = runCli("no/such.yaml", "--json", "-o", "a/b/c/d/e");
+
+    assert.equal(run.status, 1);
+    assert.equal(run.stderr, "");
+    assert.equal(JSON.parse(run.stdout).status, "error");
+    assert.match(JSON.parse(run.stdout).error, /checkOnly/);
+    assert.equal(JSON.parse(run.stdout).filter, "a/b/c/d/e");
+  });
+
+  it("writes nothing but the report to stdout when the run aborts before any config", () => {
+    const run = runCli("no/such.yaml", "--json");
+
+    assert.equal(run.status, 1);
+    assert.equal(run.stderr, "");
+    const report = JSON.parse(run.stdout);
+    assert.equal(report.status, "error");
+    assert.match(report.error, /no\/such\.yaml/);
+    assert.deepEqual(report.configs, []);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--json` / `-J`: instead of the log, stdout carries a single JSON report meant for scripts and coding agents. The exit code is unchanged, and the report carries only what needs attention: the verdict, per-config counters, failed checks with their message, and checks that could not run. Contracts whose checks all passed are not listed.

The format is specified in `docs/json-output.md` (linked from README, `docs/cli.md`, `docs/how-to.md`, `CLAUDE.md`, the `state-mate` skill and `--help`). Highlights:

- top level: `status` (`passed | failed | error`), `exit_code`, `duration_seconds`, `filter` (the `--only` argument), `summary` counters, `configs` list
- per config: path, status, `checks` / `errors` / `skipped`, and `contracts` only when a contract has `failures` (`type`, `check`, `message`) or `warnings` (a check that did not run, an ACL scan on a chain with no log source for instance)
- messages are stripped of ANSI colours; a value mismatch quotes both expected and actual
- keys with empty values are omitted, so a clean single-config run is the verdict, the counters and one config line

A run that aborts (missing config, unset env var, ABI absent from the store, usage error) still produces a report with `status: "error"` and the message in `error`; the contracts checked before the abort keep their failures. Only an unexpected exception adds its stack to stderr.

## Implementation

- `src/report.ts` collects the report on every run and writes it only under the flag; failures are read back from `stats.errorDetails`, which every error path already feeds, so validators do not branch on the output mode
- `logErrorAndExit` throws a `FatalError` under `--json` and the entrypoint turns it into the report; commander's own usage errors are routed the same way
- the report is written through the stdout stream and the exit code is set via `process.exitCode`, so a pipe receives the whole report

## Side change

A value mismatch in `_checkViewResult` was caught by the same `catch` as a revert and printed as `REVERTED with: Expected …`. The two are now separate: reverts keep the prefix, mismatches read `Expected "X" to equal actual "Y"`. This changes the log text too.

## Verification

- 219 tests pass, biome, prettier and `tsc` green; new tests in `tests/json-report.test.ts` cover the report shape, aborts mid-contract, usage errors and a CLI run whose stdout is nothing but the report
- real runs on `configs/defiwrapper/mainnet/strategy.yaml` and on a scratch copy with one wrong value, single-file and directory mode, `-o` filter, and a slow pipe consumer
- three `codex exec review` passes; the findings (failures lost on a mid-contract abort, usage errors bypassing the report, truncated pipe writes, a double report in a failed directory run) are fixed, the last pass found nothing
