### PR TITLE
fix: catch up lido-earn drifts and compare ABI stores by content in the nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,13 +59,17 @@ jobs:
           UNICHAIN_RPC_URL: ${{ secrets.UNICHAIN_RPC_URL || 'https://unichain.drpc.org' }}
         run: yarn start ${{ matrix.config }} --quiet ${{ github.event_name == 'schedule' && '--update-abi' || '' }}
 
+      # gzip stamps the writer's OS into its header, so a store committed from macOS never matches
+      # its Linux rebuild byte for byte even when every ABI does: compare the decompressed JSON
       - name: Check ABI provenance
         if: github.event_name == 'schedule'
         run: |
-          if ! git diff --exit-code -- ${{ matrix.config }}; then
-            echo "Error: the committed ABI store differs from what the explorer serves."
-            exit 1
-          fi
+          for store in $(git diff --name-only -- ${{ matrix.config }}); do
+            if ! diff <(git show "HEAD:$store" | gunzip) <(gunzip -c "$store"); then
+              echo "Error: the committed ABI store $store differs from what the explorer serves."
+              exit 1
+            fi
+          done
 
   unit:
     name: Unit Tests

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/lidofinance/state-mate/actions/workflows/ci.yaml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/lidofinance/state-mate/ci.yaml?branch=main&style=flat-square&label=CI" /></a>
+  <a href="https://github.com/lidofinance/state-mate/actions/workflows/ci.yaml?query=branch%3Amain"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/lidofinance/state-mate/ci.yaml?branch=main&style=flat-square&label=CI" /></a>
   <a href="package.json"><img alt="Node.js 24 or newer" src="https://img.shields.io/badge/Node.js-24%2B-339933?style=flat-square&logo=nodedotjs&logoColor=white" /></a>
   <a href="package.json"><img alt="Yarn 4.17.0" src="https://img.shields.io/badge/Yarn-4.17.0-2C8EBB?style=flat-square&logo=yarn&logoColor=white" /></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/github/license/lidofinance/state-mate?style=flat-square" /></a>

--- a/configs/lido-earn/mainnet/earneth-vaults.yaml
+++ b/configs/lido-earn/mainnet/earneth-vaults.yaml
@@ -118,6 +118,7 @@ misc:
   - &lidoSigner10 "0xE6CD29BF19769E44534099d241abAa07aa8c8E9a"
   - &lidoSigner11 "0x8aA493BcD7f989caD67dd3CB48A4c2E6b40FeDB0"
   - &lidoSigner12 "0xf2374BCb265505002055942D070459a4d2011012"
+  - &lidoSigner13 "0x7a63a5cc7F6A6352d0Ae1fE175D745Bce5d75657"
 
   # --- Mellow signers ---
   - &mellowSigner1 "0x44A388BBD782AE1D7f4542aEb6C3569E2CfdF5a1"
@@ -1144,8 +1145,8 @@ l1:
         feeRecipient: *treasury
         minPriceD18:
         owner: *lazyVaultAdmin
-        performanceFeeD6: 0
-        protocolFeeD6: 0
+        performanceFeeD6: 150000
+        protocolFeeD6: 2000
         redeemFeeD6: 0
         timestamps:
       implementationChecks:
@@ -1559,6 +1560,7 @@ l1:
         getChainId: 1
         getModulesPaginated:
         getOwners:
+          - *lidoSigner13
           - *lidoSigner6
           - *lidoSigner9
           - *lidoSigner2

--- a/configs/lido-earn/mainnet/earnusd-vaults-ethereum.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-ethereum.yaml
@@ -150,6 +150,7 @@ misc:
   - &lidoSigner10 "0xE6CD29BF19769E44534099d241abAa07aa8c8E9a"
   - &lidoSigner11 "0x8aA493BcD7f989caD67dd3CB48A4c2E6b40FeDB0"
   - &lidoSigner12 "0xf2374BCb265505002055942D070459a4d2011012"
+  - &lidoSigner13 "0x7a63a5cc7F6A6352d0Ae1fE175D745Bce5d75657"
 
   # --- Mellow signers ---
   - &mellowSigner1 "0x44A388BBD782AE1D7f4542aEb6C3569E2CfdF5a1"
@@ -2966,6 +2967,7 @@ l1:
         getChainId: 1
         getModulesPaginated:
         getOwners:
+          - *lidoSigner13
           - *lidoSigner6
           - *lidoSigner9
           - *lidoSigner2

--- a/configs/lido-earn/mainnet/earnusd-vaults-plasma.yaml
+++ b/configs/lido-earn/mainnet/earnusd-vaults-plasma.yaml
@@ -395,7 +395,7 @@ l1:
         getVerificationResult:
         hashCall:
         isAllowedCall:
-        merkleRoot: "0x3290cff12dc523502faa7784661dc051c8e8d9c8c06446e8c038d37f06996ebd"
+        merkleRoot: "0x11e7220e6e437097fa13c38b8f9e7bf186b9e0d807c8f47d05bb81735721f76f"
         vault: *earnUSDe_vault
         verifyCall:
       implementationChecks:


### PR DESCRIPTION
The nightly run on `main` has failed every day since the ABI provenance step landed. Two separate causes.

## ABI provenance compared bytes, not content

gzip stamps the writer's OS into byte 9 of the header. The committed stores were written on macOS (`0x13`), the nightly rebuilds them on Linux (`0x03`), so `git diff --exit-code` flagged every store even when every ABI matched. A local `--update-abi` rebuild of `configs/defiwrapper/mainnet` produces a byte-identical store, which confirms the content is in sync.

The step now decompresses the `HEAD:` version and the rebuilt store and diffs the JSON. A real ABI change still fails the job, and the log shows the actual diff instead of "Binary files differ".

## lido-earn/mainnet drifts

All three verified on-chain.

- `earneth-vaults.yaml`: FeeManager `0xed4Fac879eE86F3aB0101993A3713e7cAA0488E1` now charges `performanceFeeD6 = 150000` and `protocolFeeD6 = 2000`. Implementation checks stay at zero.
- `earneth-vaults.yaml`, `earnusd-vaults-ethereum.yaml`: the curator Safe `0xe5abcc40196174Ae0d12153dE286F0D8E401769d` gained a sixth owner, `0x7a63a5cc7F6A6352d0Ae1fE175D745Bce5d75657` (`lidoSigner13`). Threshold unchanged at 3.
- `earnusd-vaults-plasma.yaml`: `earnUSDe_verifier0` merkle root moved to `0x11e7220e6e437097fa13c38b8f9e7bf186b9e0d807c8f47d05bb81735721f76f`.

## README

The CI badge link now opens the workflow runs filtered to `branch:main`, matching what the badge itself reports.

## Not in this PR

The nightly logs show frequent `Max calls per sec rate limit reached (3/sec)` refusals from Etherscan despite `max-parallel: 1`. Refused addresses keep their stored ABI after one retry, so provenance is not actually verified for them. Worth a separate look.
