### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "state-mate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ethereum + L2s smart contract state checker",
   "main": "state-checker.ts",
   "license": "MIT",


### PR DESCRIPTION
Bumps `package.json` to 1.1.0 ahead of the v1.1.0 release. Release notes cover #179, #180, #189, #190 and #181.